### PR TITLE
When a sales order is canceled, when one uses the 'New Copy from Quotati...

### DIFF
--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -137,7 +137,8 @@ class sale_order(orm.Model):
 
     def copy_quotation(self, cr, uid, ids, context=None):
         if isinstance(ids, (tuple, list)):
-            assert len(ids) == 1, "1 ID expected, got %s" % ids
+            assert len(ids) == 1, ("1 ID expected, "
+                                   "got the following list %s" % (ids,))
         if context is None:
             context = {}
         else:
@@ -226,7 +227,7 @@ class sale_order_line(orm.Model):
 
     def create(self, cr, uid, vals, context=None):
         if context is None:
-            context= {}
+            context = {}
 
         old_line_id = None
         if context.get('__copy_from_quotation'):
@@ -255,7 +256,7 @@ class sale_order_line(orm.Model):
         if default is None:
             default = {}
         if context is None:
-            context= {}
+            context = {}
 
         default['magento_bind_ids'] = False
         data = super(sale_order_line, self).copy_data(cr, uid, id,

--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -135,6 +135,28 @@ class sale_order(orm.Model):
                                                  default=default,
                                                  context=context)
 
+    def copy_quotation(self, cr, uid, ids, context=None):
+        if isinstance(ids, (tuple, list)):
+            assert len(ids) == 1, "1 ID expected, got %s" % ids
+        if context is None:
+            context = {}
+        else:
+            context = context.copy()
+        context['__copy_from_quotation'] = True
+        result = super(sale_order, self).copy_quotation(cr, uid, ids,
+                                                        context=context)
+        # link binding of the canceled order to the new order, so the
+        # operations done on the new order will be sync'ed with Magento
+        new_id = result['res_id']
+        binding_obj = self.pool['magento.sale.order']
+        binding_ids = binding_obj.search(cr, uid,
+                                         [('openerp_id', '=', ids[0])],
+                                         context=context)
+        binding_obj.write(cr, uid, binding_ids,
+                          {'openerp_id': new_id},
+                          context=context)
+        return result
+
 
 class magento_sale_order_line(orm.Model):
     _name = 'magento.sale.order.line'
@@ -202,13 +224,53 @@ class sale_order_line(orm.Model):
             string="Magento Bindings"),
     }
 
+    def create(self, cr, uid, vals, context=None):
+        if context is None:
+            context= {}
+
+        old_line_id = None
+        if context.get('__copy_from_quotation'):
+            # when we are copying a sale.order from a canceled one,
+            # the id of the copied line is inserted in the vals
+            # in `copy_data`.
+            old_line_id = vals.pop('__copy_from_line_id', None)
+        new_id = super(sale_order_line, self).create(cr, uid, vals,
+                                                     context=context)
+        if old_line_id:
+            # link binding of the canceled order lines to the new order
+            # lines, happens when we are using the 'New Copy of
+            # Quotation' button on a canceled sales order
+            binding_obj = self.pool['magento.sale.order.line']
+            binding_ids = binding_obj.search(
+                cr, uid,
+                [('openerp_id', '=', old_line_id)],
+                context=context)
+            if binding_ids:
+                binding_obj.write(cr, uid, binding_ids,
+                                  {'openerp_id': new_id},
+                                  context=context)
+        return new_id
+
     def copy_data(self, cr, uid, id, default=None, context=None):
         if default is None:
             default = {}
+        if context is None:
+            context= {}
+
         default['magento_bind_ids'] = False
-        return super(sale_order_line, self).copy_data(cr, uid, id,
+        data = super(sale_order_line, self).copy_data(cr, uid, id,
                                                       default=default,
                                                       context=context)
+        if context.get('__copy_from_quotation'):
+            # copy_data is called by `copy` of the sale.order which
+            # builds a dict for the full new sale order, so we lose the
+            # association between the old and the new line.
+            # Keep a trace of the old id in the vals that will be passed
+            # to `create`, from there, we'll be able to update the
+            # Magento bindings, modifying the relation from the old to
+            # the new line.
+            data['__copy_from_line_id'] = id
+        return data
 
 
 @magento

--- a/magentoerpconnect/tests/__init__.py
+++ b/magentoerpconnect/tests/__init__.py
@@ -24,6 +24,7 @@ import test_address_book
 import test_export_invoice
 import test_import_product_image
 import test_related_action
+import test_sale_order
 
 
 fast_suite = [
@@ -35,4 +36,5 @@ checks = [
     test_export_invoice,
     test_import_product_image,
     test_related_action,
+    test_sale_order,
 ]

--- a/magentoerpconnect/tests/test_sale_order.py
+++ b/magentoerpconnect/tests/test_sale_order.py
@@ -42,7 +42,6 @@ class TestSaleOrder(SetUpMagentoSynchronized):
                               'magento.sale.order',
                               backend_id, 900000691)
         MagentoOrder = self.registry('magento.sale.order')
-        MagentoLine = self.registry('magento.sale.order.line')
         SaleOrder = self.registry('sale.order')
         mag_order_ids = MagentoOrder.search(self.cr,
                                             self.uid,

--- a/magentoerpconnect/tests/test_sale_order.py
+++ b/magentoerpconnect/tests/test_sale_order.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Guewen Baconnier
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.addons.magentoerpconnect.unit.import_synchronizer import (
+    import_record)
+import openerp.tests.common as common
+from .common import (mock_api,
+                     mock_urlopen_image)
+from .test_data import magento_base_responses
+from .test_synchronization import SetUpMagentoSynchronized
+
+DB = common.DB
+ADMIN_USER_ID = common.ADMIN_USER_ID
+
+
+class TestSaleOrder(SetUpMagentoSynchronized):
+
+    def test_sale_order_copy_quotation(self):
+        """ Copy a sales order with copy_quotation move bindings """
+        backend_id = self.backend_id
+        with mock_api(magento_base_responses):
+            with mock_urlopen_image():
+                import_record(self.session,
+                              'magento.sale.order',
+                              backend_id, 900000691)
+        MagentoOrder = self.registry('magento.sale.order')
+        MagentoLine = self.registry('magento.sale.order.line')
+        SaleOrder = self.registry('sale.order')
+        mag_order_ids = MagentoOrder.search(self.cr,
+                                            self.uid,
+                                            [('backend_id', '=', backend_id),
+                                             ('magento_id', '=', '900000691')])
+        self.assertEqual(len(mag_order_ids), 1)
+        mag_order = MagentoOrder.browse(self.cr, self.uid, mag_order_ids[0])
+        order = mag_order.openerp_id
+        action = SaleOrder.copy_quotation(self.cr, self.uid, [order.id])
+        new_id = action['res_id']
+        order.refresh()
+        self.assertFalse(order.magento_bind_ids)
+        mag_order.refresh()
+        self.assertEqual(mag_order.openerp_id.id, new_id)
+        for mag_line in mag_order.magento_order_line_ids:
+            self.assertEqual(mag_line.order_id.id, new_id)


### PR DESCRIPTION
...on' button,

the binding are moved from the old (canceled) order to the new one, so the
synchronizations now happen on the new order.
- [x] **Warning**: needs this PR to be merged in _addons_ https://github.com/odoo/odoo/pull/1025
- [x]  **Warning**:  needs the same fix in OCB

Original MP on Launchpad: https://code.launchpad.net/~camptocamp/openerp-connector-magento/7.0-copy-quotation-move-binding/+merge/226137
