### PR TITLE
Corrections on the export of tracking numbers:

### DIFF
--- a/magentoerpconnect/i18n/fr.po
+++ b/magentoerpconnect/i18n/fr.po
@@ -1228,3 +1228,16 @@ msgstr ""
 #: model:ir.model,name:magentoerpconnect.model_magentoerpconnect_installed
 msgid "magentoerpconnect.installed"
 msgstr "magentoerpconnect.installed"
+
+#. module: magentoerpconnect
+#: code:addons/magentoerpconnect/stock_picking.py:200
+#, python-format
+msgid "Already exported"
+msgstr "Déjà exporté"
+
+#. module: magentoerpconnect
+#: code:addons/magentoerpconnect/stock_tracking.py:100
+#, python-format
+msgid "Le bon de livraison %s n'a pas d'ID Magento, "
+"impossible d'exporter le numéro de suivi."
+msgstr ""

--- a/magentoerpconnect/i18n/magentoerpconnect.pot
+++ b/magentoerpconnect/i18n/magentoerpconnect.pot
@@ -1132,3 +1132,15 @@ msgstr ""
 msgid "magentoerpconnect.installed"
 msgstr ""
 
+#. module: magentoerpconnect
+#: code:addons/magentoerpconnect/stock_picking.py:200
+#, python-format
+msgid "Already exported"
+msgstr ""
+
+#. module: magentoerpconnect
+#: code:addons/magentoerpconnect/stock_tracking.py:100
+#, python-format
+msgid "The delivery order %s has no Magento ID, "
+"can't export the tracking number."
+msgstr ""

--- a/magentoerpconnect/stock_picking.py
+++ b/magentoerpconnect/stock_picking.py
@@ -198,6 +198,8 @@ class MagentoPickingExport(ExportSynchronizer):
         Export the picking to Magento
         """
         picking = self.session.browse(self.model._name, binding_id)
+        if picking.magento_id:
+            return _('Already exported')
         picking_method = picking.picking_method
         if picking_method == 'complete':
             args = self._get_args(picking)

--- a/magentoerpconnect/stock_picking.py
+++ b/magentoerpconnect/stock_picking.py
@@ -227,6 +227,8 @@ class MagentoPickingExport(ExportSynchronizer):
                 raise
         else:
             self.binder.bind(magento_id, binding_id)
+            # ensure that we store the external ID
+            self.session.commit()
 
 
 @on_picking_out_done

--- a/magentoerpconnect/stock_picking.py
+++ b/magentoerpconnect/stock_picking.py
@@ -252,19 +252,34 @@ def picking_out_done(session, model_name, record_id, picking_method):
 
 @on_record_create(model_names='magento.stock.picking.out')
 def delay_export_picking_out(session, model_name, record_id, vals):
-    export_picking_done.delay(session, model_name, record_id)
+    binding = session.browse(model_name, record_id)
+    # tracking number is sent when:
+    # * the picking is exported and the tracking number was already
+    #   there before the picking was done OR
+    # * the tracking number is added after the picking is done
+    # We have to keep the initial state of whether we had an
+    # tracking number in the job kwargs, because if we read the
+    # picking at the time of execution of the job, a tracking could
+    # have been added and it would be exported twice.
+    with_tracking = bool(binding.carrier_tracking_ref)
+    export_picking_done.delay(session, model_name, record_id,
+                              with_tracking=with_tracking)
 
 
 @job
 @related_action(action=unwrap_binding)
-def export_picking_done(session, model_name, record_id):
+def export_picking_done(session, model_name, record_id, with_tracking=True):
     """ Export a complete or partial delivery order. """
+    # with_tracking is True to keep a backward compatibility (jobs that
+    # are pending and miss this argument will behave the same, but
+    # it should be called with True only if the carrier_tracking_ref
+    # is True when the job is created.
     picking = session.browse(model_name, record_id)
     backend_id = picking.backend_id.id
     env = get_environment(session, model_name, backend_id)
     picking_exporter = env.get_connector_unit(MagentoPickingExport)
     res = picking_exporter.run(record_id)
 
-    if picking.carrier_tracking_ref:
+    if with_tracking and picking.carrier_tracking_ref:
         export_tracking_number.delay(session, model_name, record_id)
     return res

--- a/magentoerpconnect/stock_tracking.py
+++ b/magentoerpconnect/stock_tracking.py
@@ -89,9 +89,12 @@ class MagentoTrackingExport(ExportSynchronizer):
                                   picking.name)
 
         magento_picking_id = picking.magento_id
-        if magento_picking_id is None:
-            raise NoExternalId("No value found for the picking ID on "
-                               "Magento side, the job will be retried later.")
+        if not magento_picking_id:
+            # avoid circular reference
+            from .stock_picking import MagentoPickingExport
+            picking_exporter = self.get_connector_unit_for_model(
+                MagentoPickingExport)
+            picking_exporter.run(binding_id)
 
         self._validate(picking)
         self._check_allowed_carrier(picking, sale_binding_id.magento_id)

--- a/magentoerpconnect/stock_tracking.py
+++ b/magentoerpconnect/stock_tracking.py
@@ -22,7 +22,7 @@
 import logging
 from openerp.tools.translate import _
 from openerp.addons.connector.queue.job import job, related_action
-from openerp.addons.connector.exception import FailedJobError, NoExternalId
+from openerp.addons.connector.exception import FailedJobError
 from openerp.addons.connector.unit.synchronizer import ExportSynchronizer
 from openerp.addons.connector_ecommerce.event import on_tracking_number_added
 from .connector import get_environment

--- a/magentoerpconnect/stock_tracking.py
+++ b/magentoerpconnect/stock_tracking.py
@@ -88,19 +88,24 @@ class MagentoTrackingExport(ExportSynchronizer):
                                   "%s, can't export the tracking number." %
                                   picking.name)
 
-        magento_picking_id = picking.magento_id
-        if not magento_picking_id:
+        binder = self.get_binder_for_model()
+        magento_id = binder.to_backend(binding_id)
+        if not magento_id:
             # avoid circular reference
             from .stock_picking import MagentoPickingExport
             picking_exporter = self.get_connector_unit_for_model(
                 MagentoPickingExport)
             picking_exporter.run(binding_id)
+            magento_id = binder.to_backend(binding_id)
+        if not magento_id:
+            return FailedJobError("The delivery order %s has no Magento ID, "
+                                  "can't export the tracking number." %
+                                  picking.name)
 
         self._validate(picking)
         self._check_allowed_carrier(picking, sale_binding_id.magento_id)
         tracking_args = self._get_tracking_args(picking)
-        self.backend_adapter.add_tracking_number(magento_picking_id,
-                                                 *tracking_args)
+        self.backend_adapter.add_tracking_number(magento_id, *tracking_args)
 
 
 @on_tracking_number_added


### PR DESCRIPTION
- avoid to send twice a tracking number
- when a tracking's job is executed before the export of the picking,
  the tracking's job export the picking
