### PR TITLE
Add a 'to date' boundary to batch jobs

### DIFF
--- a/magentoerpconnect/magento_model.py
+++ b/magentoerpconnect/magento_model.py
@@ -247,7 +247,9 @@ class magento_backend(orm.Model):
             else:
                 from_date = None
             import_batch.delay(session, model,
-                               backend.id, filters={'from_date': from_date})
+                               backend.id,
+                               filters={'from_date': from_date,
+                                        'to_date': import_start_time})
         # Records from Magento are imported based on their `created_at`
         # date.  This date is set on Magento at the beginning of a
         # transaction, so if the import is run between the beginning and
@@ -380,7 +382,8 @@ class magento_website(orm.Model):
             partner_import_batch.delay(
                 session, 'magento.res.partner', backend_id,
                 {'magento_website_id': website.magento_id,
-                    'from_date': from_date})
+                 'from_date': from_date,
+                 'to_date': import_start_time})
         # Records from Magento are imported based on their `created_at`
         # date.  This date is set on Magento at the beginning of a
         # transaction, so if the import is run between the beginning and
@@ -554,7 +557,8 @@ class magento_storeview(orm.Model):
                 'magento.sale.order',
                 backend_id,
                 {'magento_storeview_id': storeview.magento_id,
-                 'from_date': from_date},
+                 'from_date': from_date,
+                 'to_date': import_start_time},
                 priority=1)  # executed as soon as possible
         # Records from Magento are imported based on their `created_at`
         # date.  This date is set on Magento at the beginning of a

--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -32,7 +32,9 @@ from openerp.addons.connector.unit.mapper import (mapping,
                                                   ImportMapper
                                                   )
 from openerp.addons.connector.exception import IDMissingInBackend
-from .unit.backend_adapter import GenericAdapter
+from .unit.backend_adapter import (GenericAdapter,
+                                   MAGENTO_DATETIME_FORMAT,
+                                   )
 from .unit.import_synchronizer import (DelayedBatchImport,
                                        MagentoImportSynchronizer
                                        )
@@ -220,7 +222,7 @@ class PartnerAdapter(GenericAdapter):
         if filters is None:
             filters = {}
 
-        dt_fmt = '%Y/%m/%d %H:%M:%S'
+        dt_fmt = MAGENTO_DATETIME_FORMAT
         if from_date is not None:
             # updated_at include the created records
             filters.setdefault('updated_at', {})

--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -210,8 +210,9 @@ class PartnerAdapter(GenericAdapter):
             else:
                 raise
 
-    def search(self, filters=None, from_date=None, magento_website_ids=None):
-        """ Search records according to some criterias and returns a
+    def search(self, filters=None, from_date=None, to_date=None,
+               magento_website_ids=None):
+        """ Search records according to some criteria and return a
         list of ids
 
         :rtype: list
@@ -219,10 +220,14 @@ class PartnerAdapter(GenericAdapter):
         if filters is None:
             filters = {}
 
+        dt_fmt = '%Y/%m/%d %H:%M:%S'
         if from_date is not None:
             # updated_at include the created records
-            str_from_date = from_date.strftime('%Y/%m/%d %H:%M:%S')
-            filters['updated_at'] = {'from': str_from_date}
+            filters.setdefault('updated_at', {})
+            filters['updated_at']['from'] = from_date.strftime(dt_fmt)
+        if to_date is not None:
+            filters.setdefault('updated_at', {})
+            filters['updated_at']['to'] = to_date.strftime(dt_fmt)
         if magento_website_ids is not None:
             filters['website_id'] = {'in': magento_website_ids}
 
@@ -242,10 +247,13 @@ class PartnerBatchImport(DelayedBatchImport):
     def run(self, filters=None):
         """ Run the synchronization """
         from_date = filters.pop('from_date', None)
+        to_date = filters.pop('to_date', None)
         magento_website_ids = [filters.pop('magento_website_id')]
-        record_ids = self.backend_adapter.search(filters,
-                                                 from_date,
-                                                 magento_website_ids)
+        record_ids = self.backend_adapter.search(
+            filters,
+            from_date=from_date,
+            to_date=to_date,
+            magento_website_ids=magento_website_ids)
         _logger.info('search for magento partners %s returned %s',
                      filters, record_ids)
         for record_id in record_ids:

--- a/magentoerpconnect/product.py
+++ b/magentoerpconnect/product.py
@@ -39,7 +39,9 @@ from openerp.addons.connector.exception import (MappingError,
 from openerp.addons.connector.unit.mapper import (mapping,
                                                   ImportMapper,
                                                   )
-from .unit.backend_adapter import GenericAdapter
+from .unit.backend_adapter import (GenericAdapter,
+                                   MAGENTO_DATETIME_FORMAT,
+                                   )
 from .unit.mapper import normalize_datetime
 from .unit.import_synchronizer import (DelayedBatchImport,
                                        MagentoImportSynchronizer,
@@ -198,7 +200,7 @@ class ProductProductAdapter(GenericAdapter):
         """
         if filters is None:
             filters = {}
-        dt_fmt = '%Y/%m/%d %H:%M:%S'
+        dt_fmt = MAGENTO_DATETIME_FORMAT
         if from_date is not None:
             filters.setdefault('updated_at', {})
             filters['updated_at']['from'] = from_date.strftime(dt_fmt)

--- a/magentoerpconnect/product_category.py
+++ b/magentoerpconnect/product_category.py
@@ -28,7 +28,9 @@ from openerp.addons.connector.unit.mapper import (mapping,
 from openerp.addons.connector.exception import (IDMissingInBackend,
                                                 MappingError,
                                                 )
-from .unit.backend_adapter import GenericAdapter
+from .unit.backend_adapter import (GenericAdapter,
+                                   MAGENTO_DATETIME_FORMAT,
+                                   )
 from .unit.import_synchronizer import (DelayedBatchImport,
                                        MagentoImportSynchronizer,
                                        TranslationImporter,
@@ -111,7 +113,7 @@ class ProductCategoryAdapter(GenericAdapter):
         if filters is None:
             filters = {}
 
-        dt_fmt = '%Y/%m/%d %H:%M:%S'
+        dt_fmt = MAGENTO_DATETIME_FORMAT
         if from_date is not None:
             filters.setdefault('updated_at', {})
             # updated_at include the created records

--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -38,7 +38,9 @@ from openerp.addons.connector_ecommerce.unit.sale_order_onchange import (
 from openerp.addons.connector_ecommerce.sale import (ShippingLineBuilder,
                                                      CashOnDeliveryLineBuilder,
                                                      GiftOrderLineBuilder)
-from .unit.backend_adapter import GenericAdapter
+from .unit.backend_adapter import (GenericAdapter,
+                                   MAGENTO_DATETIME_FORMAT,
+                                   )
 from .unit.import_synchronizer import (DelayedBatchImport,
                                        MagentoImportSynchronizer
                                        )
@@ -235,7 +237,7 @@ class SaleOrderAdapter(GenericAdapter):
         """
         if filters is None:
             filters = {}
-        dt_fmt = '%Y/%m/%d %H:%M:%S'
+        dt_fmt = MAGENTO_DATETIME_FORMAT
         if from_date is not None:
             filters.setdefault('created_at', {})
             filters['created_at']['from'] = from_date.strftime(dt_fmt)

--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -226,17 +226,22 @@ class SaleOrderAdapter(GenericAdapter):
             else:
                 raise
 
-    def search(self, filters=None, from_date=None, magento_storeview_ids=None):
-        """ Search records according to some criterias
+    def search(self, filters=None, from_date=None, to_date=None,
+               magento_storeview_ids=None):
+        """ Search records according to some criteria
         and returns a list of ids
 
         :rtype: list
         """
         if filters is None:
             filters = {}
+        dt_fmt = '%Y/%m/%d %H:%M:%S'
         if from_date is not None:
-            str_from_date = from_date.strftime('%Y/%m/%d %H:%M:%S')
-            filters['created_at'] = {'gt': str_from_date}
+            filters.setdefault('created_at', {})
+            filters['created_at']['from'] = from_date.strftime(dt_fmt)
+        if to_date is not None:
+            filters.setdefault('created_at', {})
+            filters['created_at']['to'] = to_date.strftime(dt_fmt)
         if magento_storeview_ids is not None:
             filters['store_id'] = {'in': magento_storeview_ids}
 
@@ -274,11 +279,14 @@ class SaleOrderBatchImport(DelayedBatchImport):
             filters = {}
         filters['state'] = {'neq': 'canceled'}
         from_date = filters.pop('from_date', None)
+        to_date = filters.pop('to_date', None)
         magento_storeview_ids = [filters.pop('magento_storeview_id')]
-        record_ids = self.backend_adapter.search(filters,
-                                                 from_date,
-                                                 magento_storeview_ids)
-        _logger.info('search for magento saleorders %s  returned %s',
+        record_ids = self.backend_adapter.search(
+            filters,
+            from_date=from_date,
+            to_date=to_date,
+            magento_storeview_ids=magento_storeview_ids)
+        _logger.info('search for magento saleorders %s returned %s',
                      filters, record_ids)
         for record_id in record_ids:
             self._import_record(record_id)

--- a/magentoerpconnect/unit/backend_adapter.py
+++ b/magentoerpconnect/unit/backend_adapter.py
@@ -31,6 +31,9 @@ from openerp.addons.connector.exception import (NetworkRetryableError,
 _logger = logging.getLogger(__name__)
 
 
+MAGENTO_DATETIME_FORMAT = '%Y/%m/%d %H:%M:%S'
+
+
 recorder = {}
 
 


### PR DESCRIPTION
Currently, the batch jobs have a 'from date' boundary only, which is
incremented each time a new batch job is created.

This may cause an issue when many batch jobs are created and don't have
the time to be processed: the same records will be imported several
times.

Example with 4 batch jobs with an interval of 10 minutes (the 30 seconds
difference is a buffer because Magento may commit a new record 'created_at' with a
delay) :

  Batch job 1 from 2014-07-17 10:00:00
  Batch job 2 from 2014-07-17 10:09:30
  Batch job 3 from 2014-07-17 10:19:00
  Batch job 4 from 2014-07-17 10:28:30

A product A is modified on Magento at 2014-07-17 10:25:00
None of the batch job could been executed so far (maybe an interruption
or a high load).  When the batch job 1 will be processed, it will see
that product A has been modified later than 10:00 so it creates an
import job. Turn of batch job 2, it sees the product modified after
10:10, creates an import job... and so on.

This patch adds a 'to' boundary so the batch jobs become:

  Batch job 1 from 2014-07-17 10:00:00 to 2014-07-17 10:10:00
  Batch job 2 from 2014-07-17 10:09:30 to 2014-07-17 10:19:30
  Batch job 3 from 2014-07-17 10:19:00 to 2014-07-17 10:19:00
  Batch job 4 from 2014-07-17 10:28:30 to 2014-07-17 10:28:30

Thus, in the same situation than before, only the batch job 3 would see
the record.
