### PR TITLE
When Magento returns no ID when we create an invoice...

### DIFF
--- a/magentoerpconnect/invoice.py
+++ b/magentoerpconnect/invoice.py
@@ -177,6 +177,7 @@ class MagentoInvoiceSynchronizer(ExportSynchronizer):
         mail_notification = magento_store.send_invoice_paid_mail
 
         lines_info = self._get_lines_info(invoice)
+        magento_id = None
         try:
             magento_id = self._export_invoice(magento_order.magento_id,
                                               lines_info,
@@ -191,18 +192,32 @@ class MagentoInvoiceSynchronizer(ExportSynchronizer):
                               'the invoice id.',
                               magento_order.magento_id)
                 magento_id = self._get_existing_invoice(magento_order)
+                if magento_id is None:
+                    # In that case, we let the exception bubble up so
+                    # the user is informed of the 102 error.
+                    # We couldn't find the invoice supposedly existing
+                    # so an investigation may be necessary.
+                    raise
             else:
                 raise
+        # When the invoice already exists on Magento, it may return
+        # a 102 error (handled above) or return silently without ID
+        if not magento_id:
+            # If Magento returned no ID, try to find the Magento
+            # invoice, but if we don't find it, let consider the job
+            # as done, because Magento did not raised an error
+            magento_id = self._get_existing_invoice(magento_order)
 
-        self.binder.bind(magento_id, binding_id)
+        if magento_id:
+            self.binder.bind(magento_id, binding_id)
 
     def _get_existing_invoice(self, magento_order):
         invoices = self.backend_adapter.search_read(
             order_id=magento_order.magento_order_id)
         if not invoices:
-            raise
+            return
         if len(invoices) > 1:
-            raise
+            return
         return invoices[0]['increment_id']
 
 

--- a/magentoerpconnect/unit/binder.py
+++ b/magentoerpconnect/unit/binder.py
@@ -120,6 +120,10 @@ class MagentoModelBinder(MagentoBinder):
         context = self.session.context.copy()
         context['connector_no_export'] = True
         now_fmt = datetime.now().strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+        assert external_id and binding_id, (
+            "external_id or binding_id missing, "
+            "got: %s, %s" % (external_id, binding_id)
+        )
         self.environment.model.write(
             self.session.cr,
             self.session.uid,


### PR DESCRIPTION
...try to get the invoice's ID otherwise, just consider the job as done, but do not bind with a None ID

Bug report: https://code.launchpad.net/bugs/1337778
Original MP on Launchpad: https://code.launchpad.net/~camptocamp/openerp-connector-magento/7.0-export-invoice-no-id-1337778/+merge/225628
