### PR TITLE
7.0 export partner and address

### DIFF
--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -79,7 +79,7 @@ class magento_res_partner(orm.Model):
     _inherits = {'res.partner': 'openerp_id'}
     _description = 'Magento Partner'
 
-    _rec_name = 'website_id'
+    _rec_name = 'name'
 
     def _get_mag_partner_from_website(self, cr, uid, ids, context=None):
         mag_partner_obj = self.pool['magento.res.partner']
@@ -190,6 +190,8 @@ class magento_address(orm.Model):
     _sql_constraints = [
         ('magento_uniq', 'unique(backend_id, magento_id)',
          'A partner address with same ID on Magento already exists.'),
+        ('openerp_uniq', 'unique(backend_id, openerp_id)',
+         'A partner address can only have one binding by backend.'),
     ]
 
 
@@ -558,6 +560,12 @@ class AddressAdapter(GenericAdapter):
         return [int(row['customer_address_id']) for row
                 in self._call('%s.list' % self._magento_model,
                               [filters] if filters else [{}])]
+
+    def create(self, data):
+        """ Create a record on the external system """
+        partner_id = data.pop('partner_id')
+        return self._call('%s.create' % self._magento_model,
+                          [partner_id, data])
 
 
 @magento

--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -561,11 +561,10 @@ class AddressAdapter(GenericAdapter):
                 in self._call('%s.list' % self._magento_model,
                               [filters] if filters else [{}])]
 
-    def create(self, data):
+    def create(self, customer_id, data):
         """ Create a record on the external system """
-        partner_id = data.pop('partner_id')
         return self._call('%s.create' % self._magento_model,
-                          [partner_id, data])
+                          [customer_id, data])
 
 
 @magento

--- a/magentoerpconnect/partner_view.xml
+++ b/magentoerpconnect/partner_view.xml
@@ -43,6 +43,7 @@
                         <field name="emailid"/>
                         <field name="taxvat"/>
                         <field name="newsletter"/>
+                        <field name="consider_as_company"/>
                     </group>
                 </form>
             </field>

--- a/magentoerpconnect/unit/export_synchronizer.py
+++ b/magentoerpconnect/unit/export_synchronizer.py
@@ -117,6 +117,8 @@ class MagentoBaseExporter(ExportSynchronizer):
         result = self._run(*args, **kwargs)
 
         self.binder.bind(self.magento_id, self.binding_id)
+
+        self._after_export()
         return result
 
     def _run(self):
@@ -150,7 +152,21 @@ class MagentoExporter(MagentoBaseExporter):
         """
         return self.mapper.map_record(self.binding_record)
 
-    def _validate_data(self, data):
+    def _after_export(self):
+        """ Can do several actions after exporting a record on magento """
+        pass
+
+    def _validate_create_data(self, data):
+        """ Check if the values to import are correct
+
+        Pro-actively check before the ``Model.create`` or
+        ``Model.update`` if some fields are missing
+
+        Raise `InvalidDataError`
+        """
+        return
+
+    def _validate_update_data(self, data):
         """ Check if the values to import are correct
 
         Pro-actively check before the ``Model.create`` or
@@ -167,7 +183,7 @@ class MagentoExporter(MagentoBaseExporter):
     def _create(self, data):
         """ Create the Magento record """
         # special check on data before export
-        self._validate_data(data)
+        self._validate_create_data(data)
         return self.backend_adapter.create(data)
 
     def _update_data(self, map_record, fields=None, **kwargs):
@@ -178,7 +194,7 @@ class MagentoExporter(MagentoBaseExporter):
         """ Update an Magento record """
         assert self.magento_id
         # special check on data before export
-        self._validate_data(data)
+        self._validate_update_data(data)
         self.backend_adapter.write(self.magento_id, data)
 
     def _run(self, fields=None):

--- a/magentoerpconnect_export_partner/__init__.py
+++ b/magentoerpconnect_export_partner/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-
-import consumer
-import partner
+from . import connector
+from . import consumer
+from . import partner

--- a/magentoerpconnect_export_partner/consumer.py
+++ b/magentoerpconnect_export_partner/consumer.py
@@ -26,8 +26,8 @@ from openerp.addons.connector.event import (on_record_write,
 import openerp.addons.magentoerpconnect.consumer as magentoerpconnect
 
 
-@on_record_create(model_names='magento.res.partner')
-@on_record_write(model_names='magento.res.partner')
+@on_record_create(model_names=['magento.address', 'magento.res.partner'])
+@on_record_write(model_names=['magento.address', 'magento.res.partner'])
 def delay_export(session, model_name, record_id, vals):
     magentoerpconnect.delay_export(session, model_name,
                                    record_id, vals)
@@ -39,6 +39,17 @@ def delay_export_all_bindings(session, model_name, record_id, vals):
                                                 record_id, vals)
 
 
-@on_record_unlink(model_names='magento.res.partner')
+@on_record_write(model_names='res.partner')
+def delay_export_all_bindings_for_address(session, model_name,
+                                          record_id, vals):
+    if session.context.get('connector_no_export'):
+        return
+    record = session.browse(model_name, record_id)
+    for binding in record.magento_address_bind_ids:
+        magentoerpconnect.delay_export(session, binding._model._name,
+                                       binding.id, vals)
+
+
+@on_record_unlink(model_names=['magento.res.partner', 'magento.address'])
 def delay_unlink(session, model_name, record_id):
     magentoerpconnect.delay_unlink(session, model_name, record_id)

--- a/magentoerpconnect_export_partner/partner.py
+++ b/magentoerpconnect_export_partner/partner.py
@@ -48,11 +48,11 @@ class PartnerExport(MagentoExporter):
             'magento_partner_id': self.binding_id,
         }
         if not self.binding_record.magento_address_bind_ids \
-        and not self.binding_record.consider_as_company:
+        and not self.binding_record.consider_as_company \
+        and self.binding_record.street:
             data['openerp_id'] = self.binding_record.openerp_id.id
-
+            data['is_default_billing'] = True
             if not self.binding_record.child_ids:
-                data['is_default_billing'] = True
                 data['is_default_shipping'] = True
 
             with self._retry_unique_violation():
@@ -203,6 +203,7 @@ class PartnerAddressExportMapper(ExportMapper):
     @changed_by('street', 'street2')
     @mapping
     def street(self, record):
+        street = False
         if record.street:
             street = record.street
         if record.street2:

--- a/magentoerpconnect_export_partner/partner.py
+++ b/magentoerpconnect_export_partner/partner.py
@@ -119,6 +119,13 @@ class AddressExport(MagentoExporter):
                                    "Magento : %s" %
                                    missing_fields)
 
+    def _create(self, data):
+        """ Create the Magento record """
+        # special check on data before export
+        self._validate_create_data(data)
+        customer_id = data.pop('partner_id')
+        return self.backend_adapter.create(customer_id, data)
+
 
 @magento
 class PartnerExportMapper(ExportMapper):

--- a/magentoerpconnect_export_partner/partner.py
+++ b/magentoerpconnect_export_partner/partner.py
@@ -22,6 +22,7 @@
 from openerp.addons.connector.unit.mapper import (mapping,
                                                   changed_by,
                                                   ExportMapper)
+from openerp.addons.connector.exception import InvalidDataError
 from openerp.addons.magentoerpconnect.unit.delete_synchronizer import (
     MagentoDeleteSynchronizer
 )
@@ -34,27 +35,106 @@ from openerp.addons.magentoerpconnect.backend import magento
 @magento
 class PartnerDeleteSynchronizer(MagentoDeleteSynchronizer):
     """ Partner deleter for Magento """
-    _model_name = ['magento.res.partner']
+    _model_name = ['magento.res.partner',
+                   'magento.address']
 
 
 @magento
 class PartnerExport(MagentoExporter):
     _model_name = ['magento.res.partner']
 
+    def _after_export(self):
+        data = {
+            'magento_partner_id': self.binding_id,
+        }
+        if not self.binding_record.magento_address_bind_ids \
+        and not self.binding_record.consider_as_company:
+            data['openerp_id'] = self.binding_record.openerp_id.id
+
+            if not self.binding_record.child_ids:
+                data['is_default_billing'] = True
+                data['is_default_shipping'] = True
+
+            with self._retry_unique_violation():
+                self.session.create('magento.address', data)
+
+        for child in self.binding_record.child_ids:
+            if not child.magento_address_bind_ids:
+                if child.type == 'invoice':
+                    data['is_default_billing'] = True
+                else:
+                    data['is_default_billing'] = False
+                if child.type == 'delivery':
+                    data['is_default_shipping'] = True
+                else:
+                    data['is_default_shipping'] = False
+                data['openerp_id'] = child.id
+                with self._retry_unique_violation():
+                    self.session.create('magento.address', data)
+
+    def _validate_create_data(self, data):
+        """ Check if the values to import are correct
+
+        Pro-actively check before the ``Model.create`` or
+        ``Model.update`` if some fields are missing
+
+        Raise `InvalidDataError`
+        """
+        if not data.get('email'):
+            raise InvalidDataError("The partner does not have an email "
+                                   "but it is mandatory for Magento")
+        return
+
+
+@magento
+class AddressExport(MagentoExporter):
+    _model_name = ['magento.address']
+
+    def _export_dependencies(self):
+        """ Export the dependencies for the record"""
+        relation = self.binding_record.parent_id or \
+            self.binding_record.openerp_id
+        self._export_dependency(relation, 'magento.res.partner',
+                                exporter_class=PartnerExport)
+
+    def _validate_create_data(self, data):
+        """ Check if the values to import are correct
+
+        Pro-actively check before the ``Model.create`` or
+        ``Model.update`` if some fields are missing
+
+        Raise `InvalidDataError`
+        """
+        missing_fields = []
+        for required_key in ('city', 'street', 'postcode',
+                             'country_id', 'telephone'):
+            if not data.get(required_key):
+                missing_fields.append(required_key)
+        if missing_fields:
+            raise InvalidDataError("The address does not contain one or "
+                                   "several mandatory fields for "
+                                   "Magento : %s" %
+                                   missing_fields)
+
 
 @magento
 class PartnerExportMapper(ExportMapper):
     _model_name = 'magento.res.partner'
 
-    direct = [('emailid', 'email'),
-              ('birthday', 'dob'),
-              ('created_at', 'created_at'),
-              ('updated_at', 'updated_at'),
-              ('emailid', 'email'),
-              ('taxvat', 'taxvat'),
-              ('group_id', 'group_id'),
-              ('website_id', 'website_id'),
-              ]
+    direct = [
+        ('birthday', 'dob'),
+        ('created_at', 'created_at'),
+        ('updated_at', 'updated_at'),
+        ('taxvat', 'taxvat'),
+        ('group_id', 'group_id'),
+        ('website_id', 'website_id'),
+    ]
+
+    @changed_by('email', 'emailid')
+    @mapping
+    def email(self, record):
+        email = record.emailid or record.email
+        return {'email': email}
 
     @changed_by('name')
     @mapping
@@ -68,3 +148,64 @@ class PartnerExportMapper(ExportMapper):
             lastname = record.name
             firstname = '-'
         return {'firstname': firstname, 'lastname': lastname}
+
+
+@magento
+class PartnerAddressExportMapper(ExportMapper):
+    _model_name = 'magento.address'
+
+    direct = [('zip', 'postcode'),
+              ('city', 'city'),
+              ('is_default_billing', 'is_default_billing'),
+              ('is_default_shipping', 'is_default_shipping'),
+              ('company', 'company'),
+              ]
+
+    @changed_by('parent_id', 'openerp_id')
+    @mapping
+    def partner(self, record):
+        binder = self.get_binder_for_model('magento.res.partner')
+        erp_partner_id = record.parent_id.id \
+            if record.parent_id \
+            else record.openerp_id.id
+        mag_partner_id = binder.to_backend(erp_partner_id, wrap=True)
+        return {'partner_id': mag_partner_id}
+
+    @changed_by('name')
+    @mapping
+    def names(self, record):
+        if ' ' in record.name:
+            parts = record.name.split()
+            firstname = parts[0]
+            lastname = ' '.join(parts[1:])
+        else:
+            lastname = record.name
+            firstname = '-'
+        return {'firstname': firstname, 'lastname': lastname}
+
+    @changed_by('phone', 'mobile')
+    @mapping
+    def phone(self, record):
+        return {'telephone': record.phone or record.mobile}
+
+    @changed_by('country_id')
+    @mapping
+    def country(self, record):
+        if record.country_id:
+            return {'country_id': record.country_id.code}
+
+    @changed_by('state_id')
+    @mapping
+    def region(self, record):
+        if record.state_id:
+            return {'region': record.state_id.name}
+
+    @changed_by('street', 'street2')
+    @mapping
+    def street(self, record):
+        if record.street:
+            street = record.street
+        if record.street2:
+            street = ['\n'.join([street, record.street2])]
+        if street:
+            return {'street': street}

--- a/magentoerpconnect_export_partner/partner.py
+++ b/magentoerpconnect_export_partner/partner.py
@@ -70,10 +70,11 @@ class PartnerExport(MagentoExporter):
                     child_extra_vals['is_default_billing'] = True
                 if child.type == 'delivery':
                     child_extra_vals['is_default_shipping'] = True
-                self._export_dependency(child, 'magento.address',
-                                        exporter_class=AddressExport,
-                                        binding_field='magento_address_bind_ids',
-                                        binding_extra_vals=child_extra_vals)
+                self._export_dependency(
+                    child, 'magento.address',
+                    exporter_class=AddressExport,
+                    binding_field='magento_address_bind_ids',
+                    binding_extra_vals=child_extra_vals)
 
     def _validate_create_data(self, data):
         """ Check if the values to import are correct

--- a/magentoerpconnect_export_partner/partner.py
+++ b/magentoerpconnect_export_partner/partner.py
@@ -44,9 +44,6 @@ class PartnerExport(MagentoExporter):
     _model_name = ['magento.res.partner']
 
     def _after_export(self):
-        data = {
-            'magento_partner_id': self.binding_id,
-        }
         # Condition on street field because we consider that if street
         # is false, there is no address to export on this partner.
         if (not self.binding_record.magento_address_bind_ids and
@@ -54,25 +51,27 @@ class PartnerExport(MagentoExporter):
                 self.binding_record.street):
             extra_vals = {
                 'is_default_billing': True,
+                'magento_partner_id': self.binding_id,
             }
             if not self.binding_record.child_ids:
                 extra_vals['is_default_shipping'] = True
             self._export_dependency(self.binding_record.openerp_id,
                                     'magento.address',
-                                    exporter_class=AddressExport
+                                    exporter_class=AddressExport,
                                     binding_field='magento_address_bind_ids',
                                     binding_extra_vals=extra_vals)
 
         for child in self.binding_record.child_ids:
-            child_extra_vals = {}
+            child_extra_vals = {
+                'magento_partner_id': self.binding_id,
+            }
             if not child.magento_address_bind_ids:
                 if child.type == 'invoice':
                     child_extra_vals['is_default_billing'] = True
                 if child.type == 'delivery':
                     child_extra_vals['is_default_shipping'] = True
-                data['openerp_id'] = child.id
                 self._export_dependency(child, 'magento.address',
-                                        exporter_class=AddressExport
+                                        exporter_class=AddressExport,
                                         binding_field='magento_address_bind_ids',
                                         binding_extra_vals=child_extra_vals)
 

--- a/magentoerpconnect_export_partner/tests/__init__.py
+++ b/magentoerpconnect_export_partner/tests/__init__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Florian da Costa
+#    Copyright 2014 Akretion
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import test_synchronization
+
+fast_suite = [
+]
+
+checks = [
+    test_synchronization,
+]

--- a/magentoerpconnect_export_partner/tests/test_synchronization.py
+++ b/magentoerpconnect_export_partner/tests/test_synchronization.py
@@ -23,7 +23,6 @@ from openerp.addons.magentoerpconnect.tests.test_synchronization import (
     SetUpMagentoSynchronized)
 from openerp.addons.magentoerpconnect.tests.common import (
     mock_api,
-    MagentoHelper
 )
 from openerp.addons.magentoerpconnect.unit.export_synchronizer import (
     export_record)
@@ -64,7 +63,7 @@ class SetUpMagentoWithPartner(SetUpMagentoSynchronized):
             cr, uid,
             {'name': 'Partner2 Partner2bis',
              'is_company': True,
-             'email': 'partner2@odoo.com',})
+             'email': 'partner2@odoo.com'})
         self.address = oe_partner_model.create(
             cr, uid,
             {'name': 'Contact address2',
@@ -74,7 +73,6 @@ class SetUpMagentoWithPartner(SetUpMagentoSynchronized):
              'zip': '11112',
              'country_id': country_id,
              'city': 'City contact test2'})
-
 
 
 class TestMagentoPartnerExport(SetUpMagentoWithPartner):
@@ -92,7 +90,6 @@ class TestMagentoPartnerExport(SetUpMagentoWithPartner):
         cr = self.cr
         uid = self.uid
         with mock_api(response, key_func=lambda m, a: m) as calls_done:
-            mag_address_model = self.registry('magento.address')
             mag_partner_model = self.registry('magento.res.partner')
             mag_partner_id = mag_partner_model.create(cr, uid, {
                 'website_id': self.website_id,
@@ -105,7 +102,6 @@ class TestMagentoPartnerExport(SetUpMagentoWithPartner):
             self.assertEqual(values['email'], 'partner@odoo.com')
             self.assertEqual(values['firstname'], 'Partner')
             self.assertEqual(values['lastname'], 'Partnerbis')
-
 
     def test_2_export_partner_address(self):
         """ Test export of address"""
@@ -129,7 +125,7 @@ class TestMagentoPartnerExport(SetUpMagentoWithPartner):
                 'openerp_id': self.address,
                 })
             export_record(self.session, 'magento.address', mag_address_id)
-            
+
             self.assertEqual(len(calls_done), 1)
 
             method, [partner, values] = calls_done[0]

--- a/magentoerpconnect_export_partner/tests/test_synchronization.py
+++ b/magentoerpconnect_export_partner/tests/test_synchronization.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Florian da Costa
+#    Copyright 2014 Akretion
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.addons.magentoerpconnect.tests.test_synchronization import (
+    SetUpMagentoSynchronized)
+from openerp.addons.magentoerpconnect.tests.common import (
+    mock_api,
+)
+from openerp.addons.magentoerpconnect.unit.export_synchronizer import (
+    export_record)
+
+
+class SetUpMagentoWithPartner(SetUpMagentoSynchronized):
+
+    def setUp(self):
+        super(SetUpMagentoWithPartner, self).setUp()
+        cr = self.cr
+        uid = self.uid
+        self.website_id = self.registry('magento.website').search(cr, uid, [
+            ('backend_id', '=', self.backend_id)])[0]
+        oe_partner_model = self.registry('res.partner')
+        country_id = self.registry('res.country').search(cr, uid, [
+            ('code', '=', 'BE')])[0]
+        self.partner_id = oe_partner_model.create(
+            cr, uid,
+            {'name': 'Partner Partner2',
+             'is_company': True,
+             'email': 'partner@odoo.com',
+             'street': '15, test street',
+             'phone': '0000000000',
+             'zip': '00000',
+             'country_id': country_id,
+             'city': 'City test'})
+        self.contact_id = oe_partner_model.create(
+            cr, uid,
+            {'name': 'Contact',
+             'parent_id': self.partner_id,
+             'street': '15, contact test street',
+             'phone': '111111111',
+             'zip': '11111',
+             'country_id': country_id,
+             'city': 'City contact test'})
+
+
+class TestMagentoPartnerExport(SetUpMagentoWithPartner):
+    """ Test the export from a Magento Mock.
+    """
+
+    def test_1_export_partner(self):
+        """ Test export of partner"""
+        response = {
+            'customer.create': True,
+        }
+        cr = self.cr
+        uid = self.uid
+        with mock_api(response, key_func=lambda m, a: m) as calls_done:
+            mag_address_model = self.registry('magento.address')
+            mag_partner_model = self.registry('magento.res.partner')
+            mag_partner_id = mag_partner_model.create(cr, uid, {
+                'website_id': self.website_id,
+                'openerp_id': self.partner_id,
+                })
+            export_record(self.session, 'magento.res.partner', mag_partner_id)
+            self.assertEqual(len(calls_done), 1)
+            method, [values] = calls_done[0]
+            self.assertEqual(method, 'customer.create')
+            self.assertEqual(values['email'], 'partner@odoo.com')
+            self.assertEqual(values['firstname'], 'Partner')
+            self.assertEqual(values['lastname'], 'Partner2')
+
+            mag_address_ids = mag_address_model.search(cr, uid, [
+                ('magento_partner_id', '=', mag_partner_id)])
+            self.assertEqual(len(mag_address_ids), 2)
+
+    def test_2_export_partner_address(self):
+        """ Test export of address"""
+        response = {
+            'customer_address.create': True,
+        }
+        cr = self.cr
+        uid = self.uid
+        with mock_api(response, key_func=lambda m, a: m) as calls_done:
+            mag_address_model = self.registry('magento.address')
+            mag_partner_model = self.registry('magento.res.partner')
+            mag_partner_id = mag_partner_model.create(cr, uid, {
+                'website_id': self.website_id,
+                'openerp_id': self.partner_id,
+                'magento_id': 1,
+                })
+            mag_address_id = mag_address_model.create(cr, uid, {
+                'magento_partner_id': mag_partner_id,
+                'openerp_id': self.partner_id,
+                })
+            export_record(self.session, 'magento.address', mag_address_id)
+
+            self.assertEqual(len(calls_done), 1)
+
+            method, [partner, values] = calls_done[0]
+            self.assertEqual(method, 'customer_address.create')
+            self.assertEqual(partner, 1)
+            self.assertEqual(values['postcode'], '00000')
+            self.assertEqual(values['city'], 'City test')
+            self.assertEqual(values['street'], '15, test street')
+            self.assertEqual(values['country_id'], 'BE')
+            self.assertEqual(values['telephone'], '0000000000')

--- a/magentoerpconnect_export_partner/tests/test_synchronization.py
+++ b/magentoerpconnect_export_partner/tests/test_synchronization.py
@@ -67,7 +67,7 @@ class TestMagentoPartnerExport(SetUpMagentoWithPartner):
     def test_1_export_partner(self):
         """ Test export of partner"""
         response = {
-            'customer.create': True,
+            'customer.create': 1,
         }
         cr = self.cr
         uid = self.uid
@@ -93,7 +93,7 @@ class TestMagentoPartnerExport(SetUpMagentoWithPartner):
     def test_2_export_partner_address(self):
         """ Test export of address"""
         response = {
-            'customer_address.create': True,
+            'customer_address.create': 2,
         }
         cr = self.cr
         uid = self.uid


### PR DESCRIPTION
Completion of the magentoerpconnect_export_partner module to fix the export of partners and add the export of addresses.

This PR depend of this one and need to be merged after : 
- [x] https://github.com/OCA/connector-magento/pull/33

Initial proposal on lauchpad : 
https://code.launchpad.net/~akretion-team/openerp-connector-magento/7.0-export-partner-and-address/+merge/224180
