### PR TITLE
Prevent to create duplicate bindings on invoices

### DIFF
--- a/magentoerpconnect/i18n/fr.po
+++ b/magentoerpconnect/i18n/fr.po
@@ -1241,3 +1241,8 @@ msgstr "Déjà exporté"
 msgid "Le bon de livraison %s n'a pas d'ID Magento, "
 "impossible d'exporter le numéro de suivi."
 msgstr ""
+
+#. module: magentoerpconnect
+#: sql_constraint:magento.account.invoice:0
+msgid "A Magento binding for this invoice already exists."
+msgstr "Un lien Magento pour cette facture existe déjà."

--- a/magentoerpconnect/i18n/magentoerpconnect.pot
+++ b/magentoerpconnect/i18n/magentoerpconnect.pot
@@ -1144,3 +1144,8 @@ msgstr ""
 msgid "The delivery order %s has no Magento ID, "
 "can't export the tracking number."
 msgstr ""
+
+#. module: magentoerpconnect
+#: sql_constraint:magento.account.invoice:0
+msgid "A Magento binding for this invoice already exists."
+msgstr ""

--- a/magentoerpconnect/invoice.py
+++ b/magentoerpconnect/invoice.py
@@ -57,6 +57,8 @@ class magento_account_invoice(orm.Model):
     _sql_constraints = [
         ('magento_uniq', 'unique(backend_id, magento_id)',
          'An invoice with the same ID on Magento already exists.'),
+        ('openerp_uniq', 'unique(backend_id, openerp_id)',
+         'A Magento binding for this invoice already exists.'),
     ]
 
 
@@ -218,9 +220,13 @@ def invoice_create_bindings(session, model_name, record_id):
     # we use the shop as many sale orders can be related to an invoice
     for sale in invoice.sale_ids:
         for magento_sale in sale.magento_bind_ids:
+            binding_exists = False
             for mag_inv in invoice.magento_bind_ids:
                 if mag_inv.backend_id.id == magento_sale.backend_id.id:
-                    continue
+                    binding_exists = True
+                    break
+            if binding_exists:
+                continue
             # Check if invoice state matches configuration setting
             # for when to export an invoice
             magento_stores = magento_sale.shop_id.magento_bind_ids


### PR DESCRIPTION
The correction made at becc1bf2 was not working because it was
doing a 'continue' on the inner loop but not on the outer loop.
