### PR TITLE
[IMP] skip the export if the binding do not exist anymore

### DIFF
--- a/magentoerpconnect/unit/export_synchronizer.py
+++ b/magentoerpconnect/unit/export_synchronizer.py
@@ -389,6 +389,8 @@ class MagentoExporter(MagentoBaseExporter):
 @related_action(action=unwrap_binding)
 def export_record(session, model_name, binding_id, fields=None):
     """ Export a record on Magento """
+    if not session.search(model_name, [['id', '=', binding_id]]):
+        return "The binding do not exist anymore, skip it"
     record = session.browse(model_name, binding_id)
     env = get_environment(session, model_name, record.backend_id.id)
     exporter = env.get_connector_unit(MagentoExporter)


### PR DESCRIPTION
Sometime the user can create by error a binding and delete it just after. If the job have been not processed, the job will failed. We should skip it as there is nothing to export anymore
