### PR TITLE
Magento uses 0 as a possible value for IDs.

### DIFF
--- a/magentoerpconnect/unit/binder.py
+++ b/magentoerpconnect/unit/binder.py
@@ -120,7 +120,9 @@ class MagentoModelBinder(MagentoBinder):
         context = self.session.context.copy()
         context['connector_no_export'] = True
         now_fmt = datetime.now().strftime(DEFAULT_SERVER_DATETIME_FORMAT)
-        assert external_id and binding_id, (
+        # the external ID can be 0 on Magento! Prevent False values
+        # like False, None, or "", but not 0.
+        assert (external_id or external_id == 0) and binding_id, (
             "external_id or binding_id missing, "
             "got: %s, %s" % (external_id, binding_id)
         )


### PR DESCRIPTION
This is the main reason why the external_id is stored as str, so
do not block the creation of a binding if the Magento ID is 0.

Fixes #48
