### PR TITLE
don't match res.partner.title on substrings

### DIFF
--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -512,7 +512,7 @@ class BaseAddressImportMapper(ImportMapper):
         if prefix:
             title_ids = self.session.search('res.partner.title',
                                             [('domain', '=', 'contact'),
-                                             ('shortcut', 'ilike', prefix)])
+                                             ('shortcut', '=ilike', prefix)])
             if title_ids:
                 title_id = title_ids[0]
             else:


### PR DESCRIPTION
I would like to suggest to use the =ilike operator for title matching because at least in our installations we want to distinguish between "Herr" and "Herr Dr.", for instance.
