### PR TITLE
Catch cases where record['discount_amount'] = None

### DIFF
--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -992,10 +992,14 @@ class SaleOrderLineImportMapper(ImportMapper):
 
     @mapping
     def discount_amount(self, record):
-        discount_value = float(record.get('discount_amount', 0))
-        if self.backend_record.catalog_price_tax_included:
+        discount_value = 0.0
+        row_total = 0.0
+        if record.get('discount_amount'):
+            discount_value = float(record.get('discount_amount', 0))
+        if self.backend_record.catalog_price_tax_included and \
+           record.get('row_total_incl_tax'):
             row_total = float(record.get('row_total_incl_tax', 0))
-        else:
+        elif record.get('row_total'):
             row_total = float(record.get('row_total', 0))
         discount = 0
         if discount_value > 0 and row_total > 0:

--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -992,15 +992,11 @@ class SaleOrderLineImportMapper(ImportMapper):
 
     @mapping
     def discount_amount(self, record):
-        discount_value = 0.0
-        row_total = 0.0
-        if record.get('discount_amount'):
-            discount_value = float(record.get('discount_amount', 0))
-        if self.backend_record.catalog_price_tax_included and \
-           record.get('row_total_incl_tax'):
-            row_total = float(record.get('row_total_incl_tax', 0))
-        elif record.get('row_total'):
-            row_total = float(record.get('row_total', 0))
+        discount_value = float(record.get('discount_amount') or 0)
+        if self.backend_record.catalog_price_tax_included:
+            row_total = float(record.get('row_total_incl_tax') or 0)
+        else:
+            row_total = float(record.get('row_total') or 0)
         discount = 0
         if discount_value > 0 and row_total > 0:
             discount = 100 * discount_value / row_total


### PR DESCRIPTION
Magento sometimes sends sales_order.items with the attributes 'discount_amount' set to None; this caused the float() function to fail with the error "TypeError: float() argument must be a string or a number".
