### PR TITLE
Set the proper company_id on an imported partner

### DIFF
--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -346,6 +346,17 @@ class PartnerImportMapper(ImportMapper):
         website_id = binder.to_openerp(record['website_id'])
         return {'website_id': website_id}
 
+    @only_create
+    @mapping
+    def company_id(self, record):
+        binder = self.get_binder_for_model('magento.storeview')
+        binding_id = binder.to_openerp(record['store_id'])
+        if binding_id:
+            storeview = self.session.browse('magento.storeview',
+                                            binding_id)
+            if storeview.store_id:
+                return {'company_id': storeview.store_id.company_id.id}
+
     @mapping
     def lang(self, record):
         binder = self.get_binder_for_model('magento.storeview')

--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -534,6 +534,19 @@ class BaseAddressImportMapper(ImportMapper):
                                                 'name': prefix})
         return {'title': title_id}
 
+    @only_create
+    @mapping
+    def company_id(self, record):
+        parent_id = record.get('parent_id')
+        if parent_id:
+            parent = self.session.browse('res.partner', parent_id)
+            if parent.company_id:
+                return {'company_id': parent.company_id.id}
+            else:
+                return {'company_id': False}
+        # Don't return anything, we are merging into an existing partner
+        return
+
 
 @magento
 class CompanyImportMapper(BaseAddressImportMapper):

--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -354,8 +354,9 @@ class PartnerImportMapper(ImportMapper):
         if binding_id:
             storeview = self.session.browse('magento.storeview',
                                             binding_id)
-            if storeview.store_id:
+            if storeview.store_id and storeview.store_id.company_id:
                 return {'company_id': storeview.store_id.company_id.id}
+        return {'company_id': False}
 
     @mapping
     def lang(self, record):


### PR DESCRIPTION
When a partner is being imported, the company id is not set, which leaves the choice to the system. While there is another solution proposed in #52, this makes things work until someone has the time to fix multicompany issues properly.
