### PR TITLE
Add the original authors in the magento connector extension...

### DIFF
--- a/magentoerpconnect/__openerp__.py
+++ b/magentoerpconnect/__openerp__.py
@@ -33,8 +33,7 @@
  'external_dependencies': {
      'python': ['magento'],
  },
- 'author': "Camptocamp,Akretion,"
-           "Connector Core Editors,Odoo Community Association (OCA)",
+ 'author': "Camptocamp,Akretion,Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'website': 'http://www.odoo-magento-connector.com',
  'description': """

--- a/magentoerpconnect_catalog/__openerp__.py
+++ b/magentoerpconnect_catalog/__openerp__.py
@@ -28,7 +28,7 @@
              'product_links',
              'product_images',
              ],
- 'author': "MagentoERPconnect Core Editors,Odoo Community Association (OCA)",
+ 'author': "Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'website': 'http://www.odoo-magento-connector.com',
  'description': """

--- a/magentoerpconnect_catalog/__openerp__.py
+++ b/magentoerpconnect_catalog/__openerp__.py
@@ -45,6 +45,6 @@ Extension for **Magento Connector**, add management of the product's catalog:
  'images': [],
  'demo': [],
  'data': [],
- 'installable': True,
+ 'installable': False,
  'application': False,
  }

--- a/magentoerpconnect_export_partner/__openerp__.py
+++ b/magentoerpconnect_export_partner/__openerp__.py
@@ -24,8 +24,7 @@
  'category': 'Connector',
  'depends': ['magentoerpconnect',
              ],
- 'author': "Camptocamp,Akretion,"
-           "MagentoERPconnect Core Editors,Odoo Community Association (OCA)",
+ 'author': "Camptocamp,Akretion,Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'website': 'http://www.odoo-magento-connector.com',
  'description': """

--- a/magentoerpconnect_export_partner/__openerp__.py
+++ b/magentoerpconnect_export_partner/__openerp__.py
@@ -24,7 +24,8 @@
  'category': 'Connector',
  'depends': ['magentoerpconnect',
              ],
- 'author': "MagentoERPconnect Core Editors,Odoo Community Association (OCA)",
+ 'author': "Camptocamp,Akretion,"
+           "MagentoERPconnect Core Editors,Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'website': 'http://www.odoo-magento-connector.com',
  'description': """

--- a/magentoerpconnect_options_active/__openerp__.py
+++ b/magentoerpconnect_options_active/__openerp__.py
@@ -25,8 +25,7 @@
  'depends': ['magentoerpconnect',
              ],
  'external_dependencies': {},
- 'author': "initOS GmbH & Co. KG,Connector Core Editors,"
-           "Odoo Community Association (OCA)",
+ 'author': "initOS GmbH & Co. KG,Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'website': 'http://www.odoo-magento-connector.com',
  'description': """

--- a/magentoerpconnect_options_active/__openerp__.py
+++ b/magentoerpconnect_options_active/__openerp__.py
@@ -25,7 +25,8 @@
  'depends': ['magentoerpconnect',
              ],
  'external_dependencies': {},
- 'author': "Connector Core Editors,Odoo Community Association (OCA)",
+ 'author': "initOS GmbH & Co. KG,Connector Core Editors,"
+           "Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'website': 'http://www.odoo-magento-connector.com',
  'description': """

--- a/magentoerpconnect_order_comment/__openerp__.py
+++ b/magentoerpconnect_order_comment/__openerp__.py
@@ -24,8 +24,7 @@
     'category': 'Connector',
     'depends': ['magentoerpconnect',
                 ],
-    'author': "Akretion,MagentoERPconnect Core Editors,"
-              "Odoo Community Association (OCA)",
+    'author': "Akretion,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'website': 'http://www.odoo-magento-connector.com',
     'description': """

--- a/magentoerpconnect_order_comment/__openerp__.py
+++ b/magentoerpconnect_order_comment/__openerp__.py
@@ -24,7 +24,7 @@
     'category': 'Connector',
     'depends': ['magentoerpconnect',
                 ],
-    'author': "MagentoERPconnect Core Editors,"
+    'author': "Akretion,MagentoERPconnect Core Editors,"
               "Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'website': 'http://www.odoo-magento-connector.com',

--- a/magentoerpconnect_pricing/__openerp__.py
+++ b/magentoerpconnect_pricing/__openerp__.py
@@ -24,7 +24,8 @@
  'category': 'Connector',
  'depends': ['magentoerpconnect',
              ],
- 'author': "MagentoERPconnect Core Editors,Odoo Community Association (OCA)",
+ 'author': "Camptocamp,"
+           "MagentoERPconnect Core Editors,Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'website': 'http://www.odoo-magento-connector.com',
  'description': """

--- a/magentoerpconnect_pricing/__openerp__.py
+++ b/magentoerpconnect_pricing/__openerp__.py
@@ -24,8 +24,7 @@
  'category': 'Connector',
  'depends': ['magentoerpconnect',
              ],
- 'author': "Camptocamp,"
-           "MagentoERPconnect Core Editors,Odoo Community Association (OCA)",
+ 'author': "Camptocamp,Odoo Community Association (OCA)",
  'license': 'AGPL-3',
  'website': 'http://www.odoo-magento-connector.com',
  'description': """


### PR DESCRIPTION
...Modules. Since we can now add several authors.

And set module magentoerpconnect_catalog as uninstallable

Because it does nothing and appears on apps.odoo.com as a valid module
otherwise.
