### PR TITLE
remove deprecated call to install_in_connector

### DIFF
--- a/__unported__/magentoerpconnect_export_partner/connector.py
+++ b/__unported__/magentoerpconnect_export_partner/connector.py
@@ -19,7 +19,4 @@
 #
 ##############################################################################
 
-from openerp.addons.connector.connector import install_in_connector
-
-
-install_in_connector()
+pass

--- a/__unported__/magentoerpconnect_options_active/connector.py
+++ b/__unported__/magentoerpconnect_options_active/connector.py
@@ -19,7 +19,4 @@
 #
 ##############################################################################
 
-from openerp.addons.connector.connector import install_in_connector
-
-
-install_in_connector()
+pass

--- a/__unported__/magentoerpconnect_pricing/connector.py
+++ b/__unported__/magentoerpconnect_pricing/connector.py
@@ -19,7 +19,4 @@
 #
 ##############################################################################
 
-from openerp.addons.connector.connector import install_in_connector
-
-
-install_in_connector()
+pass

--- a/customize_example/connector.py
+++ b/customize_example/connector.py
@@ -19,7 +19,4 @@
 #
 ##############################################################################
 
-from openerp.addons.connector.connector import install_in_connector
-
-
-install_in_connector()
+pass

--- a/magentoerpconnect/connector.py
+++ b/magentoerpconnect/connector.py
@@ -20,11 +20,8 @@
 ##############################################################################
 
 from openerp import models, fields
-from openerp.addons.connector.connector import (ConnectorEnvironment,
-                                                install_in_connector)
+from openerp.addons.connector.connector import ConnectorEnvironment
 from openerp.addons.connector.checkpoint import checkpoint
-
-install_in_connector()
 
 
 def get_environment(session, model_name, backend_id):


### PR DESCRIPTION
the sole presence of connector.py is all that is needed for the addon to be
considered.

See https://github.com/OCA/connector/pull/74
