### PR TITLE
Check street before split()

### DIFF
--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -514,6 +514,8 @@ class BaseAddressImportMapper(ImportMapper):
 
     @mapping
     def street(self, record):
+        if not record.get('street'):
+            return
         value = record['street']
         lines = [line.strip() for line in value.split('\n') if line.strip()]
         if len(lines) == 1:


### PR DESCRIPTION
Small PR to add a check before mapping the partner's street' attribute. This avoids an exception when `.split('\n')` is called on an empty value.
