### PR TITLE
[FIX] invalid character in header value

### DIFF
--- a/magentoerpconnect/product.py
+++ b/magentoerpconnect/product.py
@@ -332,7 +332,7 @@ class CatalogImageImporter(Importer):
             request = urllib2.Request(url)
             if self.backend_record.auth_basic_username \
                     and self.backend_record.auth_basic_password:
-                base64string = base64.encodestring(
+                base64string = base64.b64encode(
                     '%s:%s' % (self.backend_record.auth_basic_username,
                                self.backend_record.auth_basic_password))
                 request.add_header("Authorization", "Basic %s" % base64string)


### PR DESCRIPTION
`base64.encodestring` adds a trailing new line character to the returned string. This character is not allowed in in the httprequest  header. Use base64.b64encode to avoid trailing new line character in the encoded string
