### PR TITLE
IMP. Account analytic account and Fiscal Position on Sale Order.

### DIFF
--- a/magentoerpconnect/magento_model.py
+++ b/magentoerpconnect/magento_model.py
@@ -166,6 +166,21 @@ class MagentoBackend(models.Model):
         string='Magento Products',
         readonly=True,
     )
+    account_analytic_id = fields.Many2one(
+        comodel_name='account.analytic.account',
+        string='Analytic account',
+        help='If specified, this analytic account will be used to fill the '
+        'field  on the sale order created by the connector. The value can '
+        'also be specified on website or the store or the store view.'
+    )
+    fiscal_position_id = fields.Many2one(
+        comodel_name='account.fiscal.position',
+        string='Fiscal position',
+        help='If specified, this fiscal position will be used to fill the '
+        'field fiscal position on the sale order created by the connector.'
+        'The value can also be specified on website or the store or the '
+        'store view.'
+    )
 
     _sql_constraints = [
         ('sale_prefix_uniq', 'unique(sale_prefix)',
@@ -331,10 +346,59 @@ class MagentoBackend(models.Model):
         return path
 
 
+class MagentoConfigSpecializer(models.AbstractModel):
+    _name = 'magento.config.specializer'
+
+    specific_account_analytic_id = fields.Many2one(
+        comodel_name='account.analytic.account',
+        string='Specific analytic account',
+        help='If specified, this analytic account will be used to fill the '
+        'field on the sale order created by the connector. The value can '
+        'also be specified on website or the store or the store view.'
+    )
+    specific_fiscal_position_id = fields.Many2one(
+        comodel_name='account.fiscal.position',
+        string='Specific fiscal position',
+        help='If specified, this fiscal position will be used to fill the '
+        'field fiscal position on the sale order created by the connector.'
+        'The value can also be specified on website or the store or the '
+        'store view.'
+    )
+    account_analytic_id = fields.Many2one(
+        comodel_name='account.analytic.account',
+        string='Analytic account',
+        compute='_get_account_analytic_id',
+    )
+    fiscal_position_id = fields.Many2one(
+        comodel_name='account.fiscal.position',
+        string='Fiscal position',
+        compute='_get_fiscal_position_id',
+    )
+
+    @property
+    def _parent(self):
+        return getattr(self, self._parent_name)
+
+    @api.multi
+    def _get_account_analytic_id(self):
+        for this in self:
+            this.account_analytic_id = (
+                this.specific_account_analytic_id or
+                this._parent.account_analytic_id)
+
+    @api.multi
+    def _get_fiscal_position_id(self):
+        for this in self:
+            this.fiscal_position_id = (
+                this.specific_fiscal_position_id or
+                this._parent.fiscal_position_id)
+
+
 class MagentoWebsite(models.Model):
     _name = 'magento.website'
-    _inherit = 'magento.binding'
+    _inherit = ['magento.binding', 'magento.config.specializer']
     _description = 'Magento Website'
+    _parent_name = 'backend_id'
 
     _order = 'sort_order ASC, id ASC'
 
@@ -390,8 +454,9 @@ class MagentoWebsite(models.Model):
 
 class MagentoStore(models.Model):
     _name = 'magento.store'
-    _inherit = 'magento.binding'
+    _inherit = ['magento.binding', 'magento.config.specializer']
     _description = 'Magento Store'
+    _parent_name = 'website_id'
 
     name = fields.Char()
     website_id = fields.Many2one(
@@ -442,8 +507,9 @@ class MagentoStore(models.Model):
 
 class MagentoStoreview(models.Model):
     _name = 'magento.storeview'
-    _inherit = 'magento.binding'
+    _inherit = ['magento.binding', 'magento.config.specializer']
     _description = "Magento Storeview"
+    _parent_name = 'store_id'
 
     _order = 'sort_order ASC, id ASC'
 

--- a/magentoerpconnect/magento_model_view.xml
+++ b/magentoerpconnect/magento_model_view.xml
@@ -130,6 +130,8 @@
                                     <field name="sale_prefix" placeholder="mag-" />
                                     <field name="product_stock_field_id" widget="selection"
                                         domain="[('model', 'in', ['product.product', 'product.template']), ('ttype', '=', 'float')]"/>
+                                    <field name="account_analytic_id" groups="sale.group_analytic_accounting" />
+                                    <field name="fiscal_position_id"/>
                                 </group>
                             </page>
 
@@ -182,6 +184,10 @@
                             <field name="sort_order"/>
                         </group>
                         <group string="Options" name="options">
+                            <field name="account_analytic_id" groups="sale.group_analytic_accounting" class="oe_read_only"/>
+                            <field name="specific_account_analytic_id" groups="sale.group_analytic_accounting" class="oe_edit_only" />
+                            <field name="fiscal_position_id" class="oe_read_only"/>
+                            <field name="specific_fiscal_position_id" class="oe_edit_only" />
                         </group>
                         <notebook>
                             <page name="import" string="Imports">
@@ -248,6 +254,10 @@
                             <field name="website_id"/>
                         </group>
                         <group string="Options">
+                            <field name="account_analytic_id" groups="sale.group_analytic_accounting" class="oe_read_only"/>
+                            <field name="specific_account_analytic_id" groups="sale.group_analytic_accounting" class="oe_edit_only" />
+                            <field name="fiscal_position_id" class="oe_read_only"/>
+                            <field name="specific_fiscal_position_id" class="oe_edit_only" />
                             <field name="send_picking_done_mail"/>
                             <field name="send_invoice_paid_mail"/>
                             <field name="create_invoice_on"/>
@@ -304,6 +314,10 @@
                             <field name="no_sales_order_sync"/>
                         </group>
                         <group string="Options">
+                            <field name="account_analytic_id" groups="sale.group_analytic_accounting" class="oe_read_only"/>
+                            <field name="specific_account_analytic_id" groups="sale.group_analytic_accounting" class="oe_edit_only" />
+                            <field name="fiscal_position_id" class="oe_read_only"/>
+                            <field name="specific_fiscal_position_id" class="oe_edit_only" />
                             <field name="section_id" options="{'no_create': True}" groups="base.group_multi_salesteams"/>
                             <field name="lang_id" widget="selection"/>
                             <field name="catalog_price_tax_included"/>

--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -569,6 +569,18 @@ class SaleOrderImportMapper(ImportMapper):
         if team:
             return {'section_id': team.id}
 
+    @mapping
+    def project_id(self, record):
+        project_id = self.options.storeview.account_analytic_id
+        if project_id:
+            return {'project_id': project_id.id}
+
+    @mapping
+    def fiscal_position(self, record):
+        fiscal_position = self.options.storeview.fiscal_position_id
+        if fiscal_position:
+            return {'fiscal_position': fiscal_position.id}
+
     # partner_id, partner_invoice_id, partner_shipping_id
     # are done in the importer
 

--- a/magentoerpconnect/tests/test_sale_order.py
+++ b/magentoerpconnect/tests/test_sale_order.py
@@ -54,6 +54,63 @@ class TestSaleOrder(SetUpMagentoSynchronized):
         self.assertEqual(len(binding), 1)
         return binding
 
+    def test_import_options(self):
+        """Test import options such as the account_analytic_account and
+        the fiscal_position that can be specified at different level of the
+        backend models (backend, wesite, store and storeview)
+        """
+        binding = self._import_sale_order(900000691)
+        self.assertFalse(binding.project_id)
+        self.assertFalse(binding.fiscal_position)
+        # keep a reference to backend models the website
+        storeview_id = binding.storeview_id
+        store_id = storeview_id.store_id
+        website_id = store_id.website_id
+        binding.openerp_id.unlink()
+        binding.unlink()
+        # define options at the backend level
+        fp1 = self.env['account.fiscal.position'].create({'name': "fp1"})
+        account_analytic_id = self.env['account.analytic.account'].create(
+            {'name': 'aaa1'})
+        self.backend.account_analytic_id = account_analytic_id
+        self.backend.fiscal_position_id = fp1.id
+        binding = self._import_sale_order(900000691)
+        self.assertEquals(binding.project_id, account_analytic_id)
+        self.assertEquals(binding.fiscal_position, fp1)
+        binding.openerp_id.unlink()
+        binding.unlink()
+        # define options at the website level
+        account_analytic_id = self.env['account.analytic.account'].create(
+            {'name': 'aaa2'})
+        fp2 = self.env['account.fiscal.position'].create({'name': "fp2"})
+        website_id.specific_account_analytic_id = account_analytic_id
+        website_id.specific_fiscal_position_id = fp2.id
+        binding = self._import_sale_order(900000691)
+        self.assertEquals(binding.project_id, account_analytic_id)
+        self.assertEquals(binding.fiscal_position, fp2)
+        binding.openerp_id.unlink()
+        binding.unlink()
+        # define options at the store level
+        account_analytic_id = self.env['account.analytic.account'].create(
+            {'name': 'aaa3'})
+        fp3 = self.env['account.fiscal.position'].create({'name': "fp3"})
+        store_id.specific_account_analytic_id = account_analytic_id
+        store_id.specific_fiscal_position_id = fp3.id
+        binding = self._import_sale_order(900000691)
+        self.assertEquals(binding.project_id, account_analytic_id)
+        self.assertEquals(binding.fiscal_position, fp3)
+        binding.openerp_id.unlink()
+        binding.unlink()
+        # define options at the storeview level
+        account_analytic_id = self.env['account.analytic.account'].create(
+            {'name': 'aaa4'})
+        fp4 = self.env['account.fiscal.position'].create({'name': "fp4"})
+        storeview_id.specific_account_analytic_id = account_analytic_id
+        storeview_id.specific_fiscal_position_id = fp4.id
+        binding = self._import_sale_order(900000691)
+        self.assertEquals(binding.project_id, account_analytic_id)
+        self.assertEquals(binding.fiscal_position, fp4)
+
     def test_copy_quotation(self):
         """ Copy a sales order with copy_quotation move bindings """
         binding = self._import_sale_order(900000691)


### PR DESCRIPTION
It's now possible to specify the analytic account and the fiscal position to use when importing a sale order from magento. Theses options can be specified at any levels of the hierarchy of the backend models according to the needs. In  this way it become possible for exemple to specify a fiscal position to use for a specific store and take advantage of the taxes mapping defined for this specific position to map the right taxe on the sale order line
