### PR TITLE
[ADD] new module magentoerpconnect_transaction_id

### DIFF
--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -532,15 +532,8 @@ class SaleOrderImportMapper(ImportMapper):
 
     @mapping
     def payment(self, record):
-        record_method = record['payment']['method']
-        method = self.env['payment.method'].search(
-            [['name', '=', record_method]],
-            limit=1,
-        )
-        assert method, ("method %s should exist because the import fails "
-                        "in SaleOrderImporter._before_import when it is "
-                        " missing" % record['payment']['method'])
-        return {'payment_method_id': method.id}
+        payment_mapper = self.unit_for(SaleOrderPaymentImportMapper)
+        return payment_mapper.map_record(record).values(**self.options)
 
     @mapping
     def shipping_method(self, record):
@@ -949,6 +942,28 @@ class SaleOrderImporter(MagentoImporter):
 
 
 SaleOrderImport = SaleOrderImporter  # deprecated
+
+
+@magento
+class SaleOrderPaymentImportMapper(ImportMapper):
+    """ Mapper for importing the sales order payment
+
+    By default link the sale order to a payment method.
+    Extended in magentoerpconnect_transaction_id.
+    """
+    _model_name = 'magento.sale.order'
+
+    @mapping
+    def payment(self, record):
+        record_method = record['payment']['method']
+        method = self.env['payment.method'].search(
+            [['name', '=', record_method]],
+            limit=1,
+        )
+        assert method, ("method %s should exist because the import fails "
+                        "in SaleOrderImporter._before_import when it is "
+                        " missing" % record['payment']['method'])
+        return {'payment_method_id': method.id}
 
 
 @magento

--- a/magentoerpconnect_transaction_id/README.rst
+++ b/magentoerpconnect_transaction_id/README.rst
@@ -1,0 +1,57 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+================================
+magentoerpconnect_transaction_id
+================================
+
+This module let's you define on the payment method the path to a value to use as transaction id into
+the informations of a sale order returned as json by magento and map this information into
+the transaction_id field defined by OCA/bank-statement-reconcile/base_transaction_id.
+
+The main purpose is to ease the reconciliation process.
+
+Configuration
+=============
+
+For each payment method, you can define the path to the transaction_id value in
+the informations provided by magento.
+
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/107/8.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/connector-magento/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/connector-magento/issues/new?body=module:%20magentoerpconnect_transaction_id%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Laurent Mignon <laurent.mignon@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/magentoerpconnect_transaction_id/__init__.py
+++ b/magentoerpconnect_transaction_id/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/magentoerpconnect_transaction_id/__openerp__.py
+++ b/magentoerpconnect_transaction_id/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': "magentoerpconnect_transaction_id",
+    'summary': """
+        Map the payment identifier in your sale order""",
+    'author': 'ACSONE SA/NV,'
+              'Odoo Community Association (OCA)',
+    'website': "http://acsone.eu",
+    'category': 'Connector',
+    'version': '8.0.1.0.0',
+    'license': 'AGPL-3',
+    'depends': [
+        'magentoerpconnect',
+        'sale_payment_method',
+        'base_transaction_id',
+    ],
+    'data': [
+        'views/payment_method_view.xml',
+    ],
+}

--- a/magentoerpconnect_transaction_id/models/__init__.py
+++ b/magentoerpconnect_transaction_id/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import payment_method
+from . import sale

--- a/magentoerpconnect_transaction_id/models/payment_method.py
+++ b/magentoerpconnect_transaction_id/models/payment_method.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields
+
+
+class PaymentMethod(models.Model):
+    _inherit = 'payment.method'
+
+    transaction_id_path = fields.Char(
+        help=('Path to the value into the informations provided by Magento '
+              'for a sale order. Values are provided as a json dict. If the '
+              'transaction_id is in a sub dict the path must be specified '
+              'by using dots between keys to the value.'))

--- a/magentoerpconnect_transaction_id/models/sale.py
+++ b/magentoerpconnect_transaction_id/models/sale.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.addons.magentoerpconnect import sale
+from openerp.addons.connector.unit.mapper import mapping
+from openerp.addons.magentoerpconnect.backend import magento
+
+
+@magento(replacing=sale.SaleOrderPaymentImportMapper)
+class SaleOrderImportMapper(sale.SaleOrderPaymentImportMapper):
+
+    @mapping
+    def payment(self, record):
+        vals = super(SaleOrderImportMapper, self).payment(record)
+        payment_method_id = vals.get('payment_method_id')
+        if not payment_method_id:
+            return vals
+        payment_method = self.env['payment.method'].browse(payment_method_id)
+        if payment_method.transaction_id_path:
+            value = record
+            for key in payment_method.transaction_id_path.split('.'):
+                value = value.get(key)
+                if not value:
+                    break
+            vals['transaction_id'] = value
+        return vals

--- a/magentoerpconnect_transaction_id/tests/__init__.py
+++ b/magentoerpconnect_transaction_id/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_synchronization

--- a/magentoerpconnect_transaction_id/tests/test_synchronization.py
+++ b/magentoerpconnect_transaction_id/tests/test_synchronization.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.addons.magentoerpconnect.tests.test_synchronization import (
+    SetUpMagentoSynchronized)
+from openerp.addons.magentoerpconnect.tests.data_base import (
+    magento_base_responses)
+from openerp.addons.magentoerpconnect.unit.import_synchronizer import (
+    import_record)
+from openerp.addons.magentoerpconnect.tests.common import (
+    mock_api,
+    mock_urlopen_image)
+
+SALE_ORDER_DATA_MOCK_KEY = ('sales_order.info', (900000695, ))
+
+
+class TestMagentoSaleImport(SetUpMagentoSynchronized):
+    """ Test the imports from a Magento Mock.
+    """
+
+    def setUp(self):
+        super(TestMagentoSaleImport, self).setUp()
+        self.payment_method = self.env['payment.method'].search(
+            [('name', '=', 'checkmo')])
+        self.payment_method.payment_term_id = False
+
+    def test_transaction_id_mapping(self):
+        """ Test import of sale order with a payment transaction id"""
+        backend_id = self.backend_id
+        self.payment_method.transaction_id_path = 'payment.trans_id'
+        data = magento_base_responses[SALE_ORDER_DATA_MOCK_KEY]
+        data['payment']['trans_id'] = '123456'
+        with mock_api(magento_base_responses):
+            with mock_urlopen_image():
+                import_record(self.session,
+                              'magento.sale.order',
+                              backend_id, 900000695)
+
+        order_model = self.env['magento.sale.order']
+        mag_order_id = order_model.search([
+            ('backend_id', '=', backend_id),
+            ('magento_id', '=', '900000695'),
+            ])
+        self.assertEqual(len(mag_order_id), 1)
+        self.assertEqual(mag_order_id.transaction_id, '123456')
+
+    def test_transaction_id_mapping_1(self):
+        """ Test import of sale order with wrong path to the payment
+        transaction id"""
+        backend_id = self.backend_id
+        self.payment_method.transaction_id_path = 'payment.tra'
+        data = magento_base_responses[SALE_ORDER_DATA_MOCK_KEY]
+        data['payment']['trans_id'] = '123456'
+        with mock_api(magento_base_responses):
+            with mock_urlopen_image():
+                import_record(self.session,
+                              'magento.sale.order',
+                              backend_id, 900000695)
+
+        order_model = self.env['magento.sale.order']
+        mag_order_id = order_model.search([
+            ('backend_id', '=', backend_id),
+            ('magento_id', '=', '900000695'),
+            ])
+        self.assertEqual(len(mag_order_id), 1)
+        self.assertFalse(mag_order_id.transaction_id)

--- a/magentoerpconnect_transaction_id/views/payment_method_view.xml
+++ b/magentoerpconnect_transaction_id/views/payment_method_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="payment_method_view_form" model="ir.ui.view">
+            <field name="name">sale_payment_method.payment_method.view_form (magentoerpconnect_transaction_id)</field>
+            <field name="model">payment.method</field>
+            <field name="inherit_id" ref="sale_payment_method.payment_method_view_form"/>
+            <field name="arch" type="xml">
+                <field name="journal_id" position="after">
+                    <field name="transaction_id_path" placeholder="payment.last_trans_id"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/setup/magentoerpconnect_transaction_id/odoo_addons/__init__.py
+++ b/setup/magentoerpconnect_transaction_id/odoo_addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/magentoerpconnect_transaction_id/odoo_addons/magentoerpconnect_transaction_id
+++ b/setup/magentoerpconnect_transaction_id/odoo_addons/magentoerpconnect_transaction_id
@@ -1,0 +1,1 @@
+../../../magentoerpconnect_transaction_id

--- a/setup/magentoerpconnect_transaction_id/setup.py
+++ b/setup/magentoerpconnect_transaction_id/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Tests fails due to the payment term used in `SetUpMagentoBase`

``` python
        self.payment_term = self.env.ref('account.'
                                         'account_payment_term_advance')
```

I've removed the payment_term in the tests developed for this new module and the tests are successful.
