### PR TITLE
[fix] compute function of many2one now returns record not int

### DIFF
--- a/magentoerpconnect_pricing/magento_model.py
+++ b/magentoerpconnect_pricing/magento_model.py
@@ -29,7 +29,7 @@ class MagentoBackend(models.Model):
 
     @api.model
     def _get_pricelist_id(self):
-        return self.env.ref('product.list0').id
+        return self.env.ref('product.list0')
 
     pricelist_id = fields.Many2one(comodel_name='product.pricelist',
                                    string='Pricelist',


### PR DESCRIPTION
Changed the computed field to return the record not the .id 
this bug mades the module uninstallable, after change works fine.
