### PR TITLE
8.0 Add support for multi company

### DIFF
--- a/magentoerpconnect/__init__.py
+++ b/magentoerpconnect/__init__.py
@@ -14,5 +14,6 @@ from . import delivery
 from . import stock_picking
 from . import stock_tracking
 from . import payment_method
+from . import res_company
 
 from . import consumer

--- a/magentoerpconnect/__openerp__.py
+++ b/magentoerpconnect/__openerp__.py
@@ -55,6 +55,7 @@
           'stock_view.xml',
           'security/ir.model.access.csv',
           'payment_method_view.xml',
+          'res_company_view.xml',
           ],
  'installable': True,
  'application': True,

--- a/magentoerpconnect/magento_model.py
+++ b/magentoerpconnect/magento_model.py
@@ -181,6 +181,12 @@ class MagentoBackend(models.Model):
         'The value can also be specified on website or the store or the '
         'store view.'
     )
+    is_multi_company = fields.Boolean(
+        string='Is Backend Multi-Company',
+        help="If this flag is set, it is possible to choose warehouse at each "
+             "level. "
+             "When import partner, ignore company_id if this flag is set.",
+    )
 
     _sql_constraints = [
         ('sale_prefix_uniq', 'unique(sale_prefix)',

--- a/magentoerpconnect/magento_model.py
+++ b/magentoerpconnect/magento_model.py
@@ -370,6 +370,15 @@ class MagentoConfigSpecializer(models.AbstractModel):
         'The value can also be specified on website or the store or the '
         'store view.'
     )
+    specific_warehouse_id = fields.Many2one(
+        comodel_name='stock.warehouse',
+        string='Specific warehouse',
+        help='If specified, this warehouse will be used to load fill the '
+        'field warehouse (and company) on the sale order created by the '
+        'connector.'
+        'The value can also be specified on website or the store or the '
+        'store view.'
+    )
     account_analytic_id = fields.Many2one(
         comodel_name='account.analytic.account',
         string='Analytic account',
@@ -380,6 +389,10 @@ class MagentoConfigSpecializer(models.AbstractModel):
         string='Fiscal position',
         compute='_get_fiscal_position_id',
     )
+    warehouse_id = fields.Many2one(
+        comodel_name='stock.warehouse',
+        string='warehouse',
+        compute='_get_warehouse_id')
 
     @property
     def _parent(self):
@@ -398,6 +411,13 @@ class MagentoConfigSpecializer(models.AbstractModel):
             this.fiscal_position_id = (
                 this.specific_fiscal_position_id or
                 this._parent.fiscal_position_id)
+
+    @api.multi
+    def _get_warehouse_id(self):
+        for this in self:
+            this.warehouse_id = (
+                this.specific_warehouse_id or
+                this._parent.warehouse_id)
 
 
 class MagentoWebsite(models.Model):
@@ -425,6 +445,7 @@ class MagentoWebsite(models.Model):
         string='Magento Products',
         readonly=True,
     )
+    is_multi_company = fields.Boolean(related="backend_id.is_multi_company")
 
     @api.multi
     def import_partners(self):
@@ -509,6 +530,7 @@ class MagentoStore(models.Model):
              "payment method is not giving an option for this by "
              "itself. (See Payment Methods)",
     )
+    is_multi_company = fields.Boolean(related="backend_id.is_multi_company")
 
 
 class MagentoStoreview(models.Model):
@@ -550,6 +572,7 @@ class MagentoStoreview(models.Model):
              'but its sales orders should not be imported.',
     )
     catalog_price_tax_included = fields.Boolean(string='Prices include tax')
+    is_multi_company = fields.Boolean(related="backend_id.is_multi_company")
 
     @api.multi
     def import_sale_orders(self):

--- a/magentoerpconnect/magento_model.py
+++ b/magentoerpconnect/magento_model.py
@@ -576,10 +576,13 @@ class MagentoStoreview(models.Model):
 
     @api.multi
     def import_sale_orders(self):
-        session = ConnectorSession(self.env.cr, self.env.uid,
-                                   context=self.env.context)
         import_start_time = datetime.now()
         for storeview in self:
+            user_id = storeview.sudo().warehouse_id.company_id.\
+                magento_company_user_id.id or self.env.uid
+            session = ConnectorSession(self.env.cr, user_id,
+                                       context=self.env.context)
+
             if storeview.no_sales_order_sync:
                 _logger.debug("The storeview '%s' is active in Magento "
                               "but is configured not to import the "

--- a/magentoerpconnect/magento_model_view.xml
+++ b/magentoerpconnect/magento_model_view.xml
@@ -132,6 +132,7 @@
                                         domain="[('model', 'in', ['product.product', 'product.template']), ('ttype', '=', 'float')]"/>
                                     <field name="account_analytic_id" groups="sale.group_analytic_accounting" />
                                     <field name="fiscal_position_id"/>
+                                    <field name="is_multi_company"/>
                                 </group>
                             </page>
 

--- a/magentoerpconnect/magento_model_view.xml
+++ b/magentoerpconnect/magento_model_view.xml
@@ -189,6 +189,9 @@
                             <field name="specific_account_analytic_id" groups="sale.group_analytic_accounting" class="oe_edit_only" />
                             <field name="fiscal_position_id" class="oe_read_only"/>
                             <field name="specific_fiscal_position_id" class="oe_edit_only" />
+                            <field name="is_multi_company" invisible="1"/>
+                            <field name="warehouse_id" class="oe_read_only" attrs="{'invisible': [('is_multi_company', '=', False)]}"/>
+                            <field name="specific_warehouse_id" class="oe_edit_only" attrs="{'invisible': [('is_multi_company', '=', False)]}"/>
                         </group>
                         <notebook>
                             <page name="import" string="Imports">
@@ -259,6 +262,9 @@
                             <field name="specific_account_analytic_id" groups="sale.group_analytic_accounting" class="oe_edit_only" />
                             <field name="fiscal_position_id" class="oe_read_only"/>
                             <field name="specific_fiscal_position_id" class="oe_edit_only" />
+                            <field name="is_multi_company" invisible="1"/>
+                            <field name="warehouse_id" class="oe_read_only" attrs="{'invisible': [('is_multi_company', '=', False)]}"/>
+                            <field name="specific_warehouse_id" class="oe_edit_only" attrs="{'invisible': [('is_multi_company', '=', False)]}"/>
                             <field name="send_picking_done_mail"/>
                             <field name="send_invoice_paid_mail"/>
                             <field name="create_invoice_on"/>
@@ -319,6 +325,9 @@
                             <field name="specific_account_analytic_id" groups="sale.group_analytic_accounting" class="oe_edit_only" />
                             <field name="fiscal_position_id" class="oe_read_only"/>
                             <field name="specific_fiscal_position_id" class="oe_edit_only" />
+                            <field name="is_multi_company" invisible="1"/>
+                            <field name="warehouse_id" class="oe_read_only" attrs="{'invisible': [('is_multi_company', '=', False)]}"/>
+                            <field name="specific_warehouse_id" class="oe_edit_only" attrs="{'invisible': [('is_multi_company', '=', False)]}"/>
                             <field name="section_id" options="{'no_create': True}" groups="base.group_multi_salesteams"/>
                             <field name="lang_id" widget="selection"/>
                             <field name="catalog_price_tax_included"/>

--- a/magentoerpconnect/partner.py
+++ b/magentoerpconnect/partner.py
@@ -286,6 +286,8 @@ class PartnerImportMapper(ImportMapper):
     @only_create
     @mapping
     def company_id(self, record):
+        if self.backend_record.is_multi_company:
+            return {'company_id': False}
         binder = self.binder_for(model='magento.storeview')
         storeview = binder.to_openerp(record['store_id'], browse=True)
         if storeview:
@@ -497,6 +499,8 @@ class BaseAddressImportMapper(ImportMapper):
     @only_create
     @mapping
     def company_id(self, record):
+        if self.backend_record.is_multi_company:
+            return {'company_id': False}
         parent = self.options.parent_partner
         if parent:
             if parent.company_id:

--- a/magentoerpconnect/product.py
+++ b/magentoerpconnect/product.py
@@ -158,7 +158,11 @@ class MagentoProductProduct(models.Model):
         else:
             stock_field = 'virtual_available'
 
-        location = backend.warehouse_id.lot_stock_id
+        location = self.env['stock.location']
+        if self.env.context.get('location'):
+            location = location.browse(self.env.context['location'])
+        else:
+            location = backend.warehouse_id.lot_stock_id
 
         product_fields = ['magento_qty', stock_field]
         if read_fields:

--- a/magentoerpconnect/res_company.py
+++ b/magentoerpconnect/res_company.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    magento_company_user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Magento Company User",
+        help="The user attached to the company use to import sale order",
+        domain="[('company_id', '=', id)]"
+    )

--- a/magentoerpconnect/res_company_view.xml
+++ b/magentoerpconnect/res_company_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="res_company_view_form_inherit_magentoerpconnect" model="ir.ui.view">
+            <field name="name">res.company.form (magentoerpconnect)</field>
+            <field name="model">res.company</field>
+            <field name="inherit_id" ref="base.view_company_form"/>
+            <field name="priority">20</field>
+            <field name="arch" type="xml">
+                <page string="Configuration" position="inside">
+                    <group>
+                        <group string="Magento Parameters">
+                            <field name="magento_company_user_id"/>
+                        </group>
+                    </group>
+                </page>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -581,6 +581,12 @@ class SaleOrderImportMapper(ImportMapper):
         if fiscal_position:
             return {'fiscal_position': fiscal_position.id}
 
+    @mapping
+    def warehouse_id(self, record):
+        warehouse = self.options.storeview.warehouse_id
+        if warehouse:
+            return {'warehouse_id': warehouse.id}
+
     # partner_id, partner_invoice_id, partner_shipping_id
     # are done in the importer
 


### PR DESCRIPTION
The goal of this PR is to add the ability to support multi companies with the connector Magento. This PR follows the same idea as the one expressed in the blueprint of @guewen  https://blueprints.launchpad.net/openerp-connector-magento/+spec/import-multi-company multi company imp
At this stage multi company is supported for
- [X] sale.order: the sale.order are created by company
- [X] res.partner: the re.partner are created without  company if the backend is configured in multi company mode.

In our case, we don't need to import the products from magento, therefore, nothing has  been modified to support the mutli company on products.
- [ ] product.product

By default nothing is provided by magento to support different warehouses by website/store/storeview. In our case we use a specific addon for magento (from smile) and we have developped a specialized odoo addon to export the product qty by warehouse.
- [ ] stock???
