### PR TITLE
[IMP] Set addresses of guests to False as well

### DIFF
--- a/magentoerpconnect/sale.py
+++ b/magentoerpconnect/sale.py
@@ -872,13 +872,10 @@ class SaleOrderImporter(MagentoImporter):
         # the partner form or the searches. Too many adresses would
         # be displayed.
         # They are never synchronized.
-
-        # For the orders which are from guests, we let the addresses
-        # as active because they don't have an address book.
         addresses_defaults = {'parent_id': partner.id,
                               'magento_partner_id': partner_binding.id,
                               'email': record.get('customer_email', False),
-                              'active': is_guest_order,
+                              'active': False,
                               'is_magento_order_address': True}
 
         addr_mapper = self.unit_for(ImportMapper, model='magento.address')


### PR DESCRIPTION
It seems arbitrary to have guests' addresses as active in the system, as opposed to logged-in customers. The duplication (there are always two additional addresses apart from the partner itself) is still pretty annoying.
