### PR TITLE
[FIX][9.0] magentoerpconnect: Assertion for zero record

### DIFF
--- a/magentoerpconnect/unit/binder.py
+++ b/magentoerpconnect/unit/binder.py
@@ -119,7 +119,9 @@ class MagentoModelBinder(MagentoBinder):
         """
         # the external ID can be 0 on Magento! Prevent False values
         # like False, None, or "", but not 0.
-        assert (external_id or external_id == 0) and binding_id, (
+        assert (
+            external_id or not isinstance(external_id, int)
+        ) and binding_id, (
             "external_id or binding_id missing, "
             "got: %s, %s" % (external_id, binding_id)
         )

--- a/magentoerpconnect/unit/binder.py
+++ b/magentoerpconnect/unit/binder.py
@@ -119,9 +119,7 @@ class MagentoModelBinder(MagentoBinder):
         """
         # the external ID can be 0 on Magento! Prevent False values
         # like False, None, or "", but not 0.
-        assert (
-            external_id or not isinstance(external_id, int)
-        ) and binding_id, (
+        assert (external_id or external_id is 0) and binding_id, (
             "external_id or binding_id missing, "
             "got: %s, %s" % (external_id, binding_id)
         )


### PR DESCRIPTION
This fixes the zero record assertion, please see below example which clarifies edge case. Intent of this method was to fail on a False, but that is not currently the case

```
>>> external_id = False
>>> binding_id = True
>>> assert (external_id or external_id == 0) and binding_id
# No assertion raised
```

My fix seems to hit the intent:

```
>>> assert (external_id or not isinstance(external_id, int)) and binding_id
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
```

I'll create a PR for this for v8 as well too, just figured we would rock out one at a time in case there is a better suggestion or I am being dumb in the intent inference.
