### PR TITLE
Better assignment of main category

### DIFF
--- a/magentoerpconnect/product.py
+++ b/magentoerpconnect/product.py
@@ -468,13 +468,10 @@ class ProductImportMapper(ImportMapper):
     def categories(self, record):
         mag_categories = record['categories']
         binder = self.binder_for('magento.product.category')
-        curr_product = self.binder_for('magento.product.product').to_openerp(
-            record['product_id'], unwrap=True
-        )
-        curr_product_rec = self.env['product.product'].browse(curr_product)
-        category_ids = []
+        product_id=[]
+	curr_product = self.binder_for('magento.product.product').to_openerp(record['product_id'], browse=True)
+	category_ids = []
         main_categ_id = None
-
         for mag_category_id in mag_categories:
             cat_id = binder.to_openerp(mag_category_id, unwrap=True)
             if cat_id is None:
@@ -487,7 +484,7 @@ class ProductImportMapper(ImportMapper):
         #do not pop from extra categories
         if category_ids:
             main_categ_id = category_ids[0]
-        
+
         if main_categ_id is None:
             default_categ = self.backend_record.default_category_id
             if default_categ:
@@ -497,9 +494,8 @@ class ProductImportMapper(ImportMapper):
         # OpenERP assign 'All Products' if not specified
         # skip main cat assignment if the current main category is already in
         # categ_ids
-
-        if (main_categ_id and
-              curr_product_rec.categ_id not in category_ids):
+	if ((main_categ_id and not curr_product) or
+                (main_categ_id and curr_product.categ_id not in category_ids)):
             result['categ_id'] = main_categ_id
         return result
 

--- a/magentoerpconnect/product.py
+++ b/magentoerpconnect/product.py
@@ -491,7 +491,11 @@ class ProductImportMapper(ImportMapper):
                 main_categ_id = default_categ.id
 
         result = {'categ_ids': [(6, 0, category_ids)]}
-        if main_categ_id:  # OpenERP assign 'All Products' if not specified
+        # OpenERP assign 'All Products' if not specified
+        # skip main cat assignment if the current main category is already in
+        # categ_ids
+        if (main_categ_id and
+                self.backend_record.categ_id.id not in category_ids):
             result['categ_id'] = main_categ_id
         return result
 

--- a/magentoerpconnect/product.py
+++ b/magentoerpconnect/product.py
@@ -72,8 +72,7 @@ class MagentoProductProduct(models.Model):
             ('simple', 'Simple Product'),
             ('configurable', 'Configurable Product'),
             ('virtual', 'Virtual Product'),
-            ('downloadable', 'Downloadable Product'),
-            # XXX activate when supported
+            ('downloadable', 'Downloadable Product'),# XXX activate when supported
             # ('grouped', 'Grouped Product'),
             # ('bundle', 'Bundle Product'),
         ]
@@ -469,7 +468,10 @@ class ProductImportMapper(ImportMapper):
     def categories(self, record):
         mag_categories = record['categories']
         binder = self.binder_for('magento.product.category')
-
+        curr_product = self.binder_for('magento.product.product').to_openerp(
+            record['product_id']
+        )
+        curr_product_rec = self.env['product.product'].browse(curr_product)
         category_ids = []
         main_categ_id = None
 
@@ -482,9 +484,10 @@ class ProductImportMapper(ImportMapper):
 
             category_ids.append(cat_id)
 
+        #do not pop from extra categories
         if category_ids:
-            main_categ_id = category_ids.pop(0)
-
+            main_categ_id = category_ids[0]
+        
         if main_categ_id is None:
             default_categ = self.backend_record.default_category_id
             if default_categ:
@@ -494,8 +497,9 @@ class ProductImportMapper(ImportMapper):
         # OpenERP assign 'All Products' if not specified
         # skip main cat assignment if the current main category is already in
         # categ_ids
+
         if (main_categ_id and
-                self.backend_record.categ_id.id not in category_ids):
+              curr_product_rec.categ_id not in category_ids):
             result['categ_id'] = main_categ_id
         return result
 

--- a/magentoerpconnect/product.py
+++ b/magentoerpconnect/product.py
@@ -469,7 +469,7 @@ class ProductImportMapper(ImportMapper):
         mag_categories = record['categories']
         binder = self.binder_for('magento.product.category')
         curr_product = self.binder_for('magento.product.product').to_openerp(
-            record['product_id']
+            record['product_id'], unwrap=True
         )
         curr_product_rec = self.env['product.product'].browse(curr_product)
         category_ids = []


### PR DESCRIPTION
When fetching categories from magento the connector returns a list of category ids.
To decide which one will be updated as categ_id  (main category)  the connector pops the last element of the categories and elects it as the main category of the product.
This randomness may cause unpredictable behaviour on update when using multiple categories in magento.
We had a client who wanted some products to be category:  product_price/ 6 and product_price 5.
when updating products the connector would substitute some of the categories of some products and leave other intact.  (depending on wich category happened to be the last in the magento category list.)

We are adding a little bit more logic to this decision. If the current main category of the odoo product exists already in the list of returned categories from magento, do not update the main category at all. 
