### PR TITLE
[FIX] basic auth product image download: header must not contain newline

### DIFF
--- a/magentoerpconnect/product.py
+++ b/magentoerpconnect/product.py
@@ -362,7 +362,7 @@ class CatalogImageImporter(ImportSynchronizer):
             request = urllib2.Request(url)
             if self.backend_record.auth_basic_username \
                     and self.backend_record.auth_basic_password:
-                base64string = base64.encodestring(
+                base64string = base64.b64encode(
                     '%s:%s' % (self.backend_record.auth_basic_username,
                                self.backend_record.auth_basic_password))
                 request.add_header("Authorization", "Basic %s" % base64string)


### PR DESCRIPTION
I use magentoerpconnect to connect OpenERP with a Magento store which is protected by HTTP basic auth. When I import a product, I get the following exception:
``` File "/srv/openerp/odoo/parts/OCA/connector-magento/magentoerpconnect/product.py", line 369, in _get_binary_image
    binary = urllib2.urlopen(request)
  File "/usr/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 429, in open
    response = self._open(req, data)
  File "/usr/lib/python2.7/urllib2.py", line 447, in _open
    '_open', req)
  File "/usr/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 1228, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/usr/lib/python2.7/urllib2.py", line 1195, in do_open
    h.request(req.get_method(), req.get_selector(), req.data, headers)
  File "/usr/lib/python2.7/httplib.py", line 1057, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 1096, in _send_request
    self.putheader(hdr, value)
  File "/usr/lib/python2.7/httplib.py", line 1035, in putheader
    raise ValueError('Invalid header value %r' % (one_value,))
ValueError: Invalid header value 'Basic xxxxxxxxxxxx\n'
```
The problem is the `\n` at the end. This patch solves the problem by using a different function for encoding.
Compare
```
In [12]: base64.b64encode('abba')
Out[12]: 'YWJiYQ=='

In [13]: base64.encodestring('abba')
Out[13]: 'YWJiYQ==\n'
```