### PR TITLE
Add financial contributors for Odoo 8.0 migration

### DIFF
--- a/magentoerpconnect/doc/conf.py
+++ b/magentoerpconnect/doc/conf.py
@@ -39,6 +39,7 @@ def add_path(*paths):
         os.path.join(*paths)
     )
 
+
 add_path(odoo_root, 'openerp', 'addons')
 add_path(odoo_root, 'addons')
 add_path(build_path)

--- a/magentoerpconnect/doc/project/contributors.rst
+++ b/magentoerpconnect/doc/project/contributors.rst
@@ -21,10 +21,24 @@ Special thanks to:
 Financial Contributors
 ######################
 
-A fund raising has been done during the year 2013, allowing us to develop
-the connector framework and the Magento connector.
+Several fund raisings have been run since 2013. One for the initial development
+of the framework and the Magento connector and a second one for the migration
+to Odoo 8.0.
 
-Here is the list of the funders, ordered by the amount of the contribution:
+Odoo 8.0 funding:
+
+* **Ursa Information Systems Inc.**
+* **Debonix**
+* **OpenBIG**
+* **Burn Controllers**
+* **Logic Supply**
+* Intero Technologies GmbH
+* Credativ
+* Olivier Sabbah
+* bmark25
+* and more, see: https://www.indiegogo.com/projects/odoo-magento-connector-for-odoo-8-by-camptocamp#/backers
+
+Initial funding:
 
 * **Logic Supply**
 * **Debonix**

--- a/magentoerpconnect/magento_model.py
+++ b/magentoerpconnect/magento_model.py
@@ -731,5 +731,6 @@ class StoreAddCheckpoint(ConnectorUnit):
                        binding_id,
                        self.backend_record.id)
 
+
 # backward compatibility
 StoreViewAddCheckpoint = magento(StoreAddCheckpoint)

--- a/magentoerpconnect/unit/backend_adapter.py
+++ b/magentoerpconnect/unit/backend_adapter.py
@@ -23,12 +23,16 @@ import socket
 import logging
 import xmlrpclib
 
-import magento as magentolib
 from openerp.addons.connector.unit.backend_adapter import CRUDAdapter
 from openerp.addons.connector.exception import (NetworkRetryableError,
                                                 RetryableJobError)
 from datetime import datetime
 _logger = logging.getLogger(__name__)
+
+try:
+    import magento as magentolib
+except ImportError as err:
+    _logger.debug('Cannot `import magento`.')
 
 
 MAGENTO_DATETIME_FORMAT = '%Y/%m/%d %H:%M:%S'


### PR DESCRIPTION
We have had large contributions to migrate the connector to Odoo 8.0.
It's only fair to add them on the financial contributor page.