### PR TITLE
10.0 Add Magento Enterprise 'payment' methods.

### DIFF
--- a/connector_magento/components/__init__.py
+++ b/connector_magento/components/__init__.py
@@ -7,3 +7,4 @@ from . import importer
 from . import exporter
 from . import mapper
 from . import deleter
+from . import line_builder

--- a/connector_magento/components/line_builder.py
+++ b/connector_magento/components/line_builder.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# © 2017 Hibou Corp.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+"""
+
+Line Builders for Magento psudo-payment methods (Store Credit, Rewards...).
+
+"""
+
+from odoo.addons.component.core import Component
+
+
+class StoreCreditLineBuilder(Component):
+    """ Return values for a Store Credit line """
+
+    _name = 'magento.order.line.builder.store_credit'
+    _inherit = 'ecommerce.order.line.builder'
+    _usage = 'order.line.builder.magento.store_credit'
+
+    def __init__(self, work_context):
+        super(StoreCreditLineBuilder, self).__init__(work_context)
+        self.product_ref = ('connector_magento',
+                            'product_product_store_credit')
+        self.sign = -1
+        self.sequence = 991
+
+
+class RewardsLineBuilder(Component):
+    """ Return values for a Rewards line """
+
+    _name = 'magento.order.line.builder.rewards'
+    _inherit = 'ecommerce.order.line.builder'
+    _usage = 'order.line.builder.magento.rewards'
+
+    def __init__(self, work_context):
+        super(RewardsLineBuilder, self).__init__(work_context)
+        self.product_ref = ('connector_magento',
+                            'product_product_rewards')
+        self.sign = -1
+        self.sequence = 992

--- a/connector_magento/data/connector_magento_data.xml
+++ b/connector_magento/data/connector_magento_data.xml
@@ -118,5 +118,23 @@ if sale.magento_bind_ids and abs(sale.amount_tax - sale.magento_bind_ids[0].tota
             <field name="active" eval="True"/>
         </record>
 
+        <record id="product_product_store_credit" model="product.product">
+            <field name="default_code">MAGENTO STORE CREDIT</field>
+            <field name="list_price">0.0</field>
+            <field name="standard_price">0.0</field>
+            <field name="type">service</field>
+            <field name="name">Magento Store Credit</field>
+            <field name="categ_id" ref="connector_ecommerce.product_categ_services" />
+        </record>
+
+        <record id="product_product_rewards" model="product.product">
+            <field name="default_code">MAGENTO REWARDS</field>
+            <field name="list_price">0.0</field>
+            <field name="standard_price">0.0</field>
+            <field name="type">service</field>
+            <field name="name">Magento Rewards</field>
+            <field name="categ_id" ref="connector_ecommerce.product_categ_services" />
+        </record>
+
     </data>
 </odoo>

--- a/connector_magento/models/sale_order/importer.py
+++ b/connector_magento/models/sale_order/importer.py
@@ -4,6 +4,7 @@
 
 import logging
 
+from re import search as re_search
 from datetime import datetime, timedelta
 
 from odoo import _
@@ -177,9 +178,7 @@ class SaleOrderImportMapper(Component):
 
     def _add_gift_certificate_line(self, map_record, values):
         record = map_record.source
-        if 'gift_cert_amount' not in record:
-            return values
-        # if gift_cert_amount is zero
+        # if gift_cert_amount is zero or doesn't exist
         if not record.get('gift_cert_amount'):
             return values
         amount = float(record['gift_cert_amount'])
@@ -191,11 +190,31 @@ class SaleOrderImportMapper(Component):
         values['order_line'].append(line)
         return values
 
+    def _add_gift_cards_line(self, map_record, values):
+        record = map_record.source
+        # if gift_cards_amount is zero or doesn't exist
+        if not record.get('gift_cards_amount'):
+            return values
+        amount = float(record['gift_cards_amount'])
+        line_builder = self.component(usage='order.line.builder.gift')
+        line_builder.price_unit = amount
+        if 'gift_cards' in record:
+            gift_code = ''
+            gift_cards_serialized = record.get('gift_cards')
+            codes = re_search(r's:1:"c";s:\d+:"(.*?)"', gift_cards_serialized)
+            if codes:
+                gift_code = ', '.join(codes.groups())
+            line_builder.gift_code = gift_code
+        line = (0, 0, line_builder.get_line())
+        values['order_line'].append(line)
+        return values
+
     def finalize(self, map_record, values):
         values.setdefault('order_line', [])
         values = self._add_shipping_line(map_record, values)
         values = self._add_cash_on_delivery_line(map_record, values)
         values = self._add_gift_certificate_line(map_record, values)
+        values = self._add_gift_cards_line(map_record, values)
         values.update({
             'partner_id': self.options.partner_id,
             'partner_invoice_id': self.options.partner_invoice_id,

--- a/connector_magento/models/sale_order/importer.py
+++ b/connector_magento/models/sale_order/importer.py
@@ -182,6 +182,8 @@ class SaleOrderImportMapper(Component):
         if not record.get('gift_cert_amount'):
             return values
         amount = float(record['gift_cert_amount'])
+        if amount == 0.0:
+            return values
         line_builder = self.component(usage='order.line.builder.gift')
         line_builder.price_unit = amount
         if 'gift_cert_code' in record:
@@ -196,6 +198,8 @@ class SaleOrderImportMapper(Component):
         if not record.get('gift_cards_amount'):
             return values
         amount = float(record['gift_cards_amount'])
+        if amount == 0.0:
+            return values
         line_builder = self.component(usage='order.line.builder.gift')
         line_builder.price_unit = amount
         if 'gift_cards' in record:


### PR DESCRIPTION
I don't know where the original implementation's `gift_cert_amount` comes from, but here are similar methods for MageEE methods `gift_cards_amount`, `customer_balance_amount`, and `reward_currency_amount`.

