### PR TITLE
[10.0]Add new wizard to read data from magento

### DIFF
--- a/connector_magento/__init__.py
+++ b/connector_magento/__init__.py
@@ -5,3 +5,4 @@
 
 from . import components
 from . import models
+from . import wizards

--- a/connector_magento/__manifest__.py
+++ b/connector_magento/__manifest__.py
@@ -38,6 +38,7 @@
           'views/delivery_views.xml',
           'views/stock_views.xml',
           'views/account_payment_mode_views.xml',
+          'wizards/magento_binding_backend_read.xml',
           ],
  'installable': True,
  'application': False,

--- a/connector_magento/wizards/__init__.py
+++ b/connector_magento/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import magento_binding_backend_read

--- a/connector_magento/wizards/magento_binding_backend_read.py
+++ b/connector_magento/wizards/magento_binding_backend_read.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import base64
+import logging
+import cStringIO
+import contextlib
+import json
+
+from odoo.exceptions import UserError
+
+from odoo import api, fields, models, tools, _
+from odoo.addons.component import core
+
+_logger = logging.getLogger(__name__)
+
+
+class MagentoBindingBackendRead(models.TransientModel):
+
+    _name = 'magento.binding.backend.read'
+
+    @api.model
+    @tools.ormcache_context('self._uid', 'model_name', keys=('lang',))
+    def _get_translated_model_name(self, model_name):
+        # get the translated model name to build
+        # a meaningful model description
+        search_result = self.env['ir.model'].name_search(
+            model_name, operator='=')
+        if search_result:
+            return search_result[0][1]
+        return self.env[model_name]._description
+
+    @api.model
+    def _default_magento_backend_id(self):
+        active_model = self._context.get('active_model')
+        if active_model and active_model == self._name:
+            # method called when the result is displayed
+            return self.env['magento.backend'].browse([])
+        if active_model and active_model != 'magento.backend':
+            raise UserError(_("The wizard must be launched from a magento "
+                              "backend model"))
+        active_id = self._context.get('active_ids', [])
+        if len(active_id) > 1:
+            raise UserError(_("The wizard must be launched on a single "
+                              "magento backend instance"))
+        active_id = (active_id and active_id[0]) or self._context.get(
+            'active_id')
+        return self.env['magento.backend'].browse(active_id)
+
+    @api.model
+    def _get_magento_binding_model(self):
+        """
+        This method return a list of magento bindings for which a backend
+        adapter is registered
+        :return:
+        """
+        try:
+            components_registry = core._component_databases[self.env.cr.dbname]
+        except KeyError:
+            _logger.info(
+                'No component registry for database %s. '
+                'Probably because the Odoo registry has not been built '
+                'yet.', exc_info=1
+            )
+            return []
+        component_classes = components_registry.lookup(
+            collection_name='magento.backend',
+            usage='backend.adapter',
+        )
+        ret = []
+        for component_class in component_classes:
+            ret.append(
+                (component_class._apply_on,
+                 self._get_translated_model_name(component_class._apply_on))
+            )
+        return ret
+
+    name = fields.Char(
+        'File Name',
+        readonly=True
+    )
+    data = fields.Binary(
+        'File',
+        readonly=True
+    )
+    state = fields.Selection(
+        [('choose', 'choose'),
+         ('get', 'get')],
+        default='choose'
+    )
+    magento_backend_id = fields.Many2one(
+        'magento.backend',
+        required=True,
+        readonly=True,
+        default=_default_magento_backend_id,
+    )
+    magento_binding_model = fields.Selection(
+        '_get_magento_binding_model',
+        required=True
+    )
+    magento_id = fields.Char(
+        'Magento Id',
+        required=True
+    )
+
+    @api.multi
+    def action_get_info(self):
+        self.ensure_one()
+
+        with self.magento_backend_id.work_on(
+                self.magento_binding_model) as work:
+            adapter = work.component(usage='backend.adapter')
+            data = adapter.read(self.magento_id)
+        with contextlib.closing(cStringIO.StringIO()) as buf:
+            json.dump(data, buf)
+            out = base64.encodestring(buf.getvalue())
+
+        name = 'sale_order_%s.json' % self.magento_id
+        self.write({'state': 'get', 'data': out, 'name': name})
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'magento.binding.backend.read',
+            'view_mode': 'form',
+            'view_type': 'form',
+            'res_id': self.id,
+            'views': [(False, 'form')],
+            'target': 'new',
+        }

--- a/connector_magento/wizards/magento_binding_backend_read.xml
+++ b/connector_magento/wizards/magento_binding_backend_read.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="magento_binding_backend_read_form_view">
+        <field name="name">magento.binding.backend.read.form (in connector_magento)</field>
+        <field name="model">magento.binding.backend.read</field>
+        <field name="arch" type="xml">
+            <form string="Read Binding information from backend">
+                <group states="choose">
+                    <field name="state" invisible="1"/>
+                    <field name="name" invisible="1"/>
+                    <field name="magento_backend_id"/>
+                    <field name="magento_binding_model"/>
+                    <field name="magento_id"/>
+                </group>
+                <div states="get">
+                    <p>Here is the file with information read drom the backend: <field name="data" readonly="1" filename="name"/></p>
+                </div>
+                <footer states="choose">
+                    <button name="action_get_info" string="Get" type="object" class="btn-primary"/>
+                    <button special="cancel" string="Cancel" type="object" class="btn-default"/>
+                </footer>
+                <footer states="get">
+                    <button special="cancel" string="Close" type="object" class="btn-primary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="magento_binding_backend_read_act_window">
+        <field name="name">Read information from backend</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">magento.binding.backend.read</field>
+        <field name="view_mode">form</field>
+        <field name="view_type">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <record model="ir.values" id="magento_binding_backend_read_act_multi">
+        <field name="name">Read information from backend</field>
+        <field name="key2">client_action_multi</field>
+        <field name="value" eval="'ir.actions.act_window,' +str(ref('magento_binding_backend_read_act_window'))" />
+        <field name="model">magento.backend</field>
+    </record>
+
+
+</odoo>


### PR DESCRIPTION
This wizard is useful when diagnosing a problem into the backend to get the json  returned by magento when you call the read method on a magento model.
The wizard is available on the backend.