### PR TITLE
[FIX] ValueError Expected singleton in Tests: test_export_tracking_after_done

### DIFF
--- a/magentoerpconnect/delivery.py
+++ b/magentoerpconnect/delivery.py
@@ -71,4 +71,4 @@ class DeliveryCarrier(models.Model):
     def _compute_carrier_code(self):
         for carrier in self:
             if carrier.magento_code:
-                self.magento_carrier_code = carrier.magento_code.split('_')[0]
+                carrier.magento_carrier_code = carrier.magento_code.split('_')[0]


### PR DESCRIPTION
Got an error while testing some magento related additions in my own runbot.

2019-11-22 14:04:27,726 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: Traceback (most recent call last):
2019-11-22 14:04:27,738 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/magentoerpconnect/tests/test_export_picking.py", line 206, in test_export_tracking_after_done
2019-11-22 14:04:27,748 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     self.picking.carrier_tracking_ref = 'XYZ'
2019-11-22 14:04:27,760 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/fields.py", line 871, in __set__
2019-11-22 14:04:27,772 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     record.write({self.name: self.convert_to_write(value)})
2019-11-22 14:04:27,788 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/api.py", line 266, in wrapper
2019-11-22 14:04:27,802 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     return new_api(self, *args, **kwargs)
2019-11-22 14:04:27,815 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/connector_ecommerce/stock.py", line 44, in write
2019-11-22 14:04:27,832 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     on_tracking_number_added.fire(session, self._name, record_id)
2019-11-22 14:04:27,846 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/connector/event.py", line 148, in fire
2019-11-22 14:04:27,854 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     consumer(*args, **kwargs)
2019-11-22 14:04:27,868 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/magentoerpconnect/stock_tracking.py", line 126, in delay_export_tracking_number
2019-11-22 14:04:27,880 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     priority=20)
2019-11-22 14:04:27,890 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/home/odoo/.local/lib/python2.7/site-packages/mock/mock.py", line 1062, in __call__
2019-11-22 14:04:27,898 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     return _mock_self._mock_call(*args, **kwargs)
2019-11-22 14:04:27,908 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/home/odoo/.local/lib/python2.7/site-packages/mock/mock.py", line 1128, in _mock_call
2019-11-22 14:04:27,920 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     ret_val = effect(*args, **kwargs)
2019-11-22 14:04:27,932 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/magentoerpconnect/tests/common.py", line 94, in clean_args_for_func
2019-11-22 14:04:27,948 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     job_func(*args, **kwargs)
2019-11-22 14:04:27,961 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/magentoerpconnect/stock_tracking.py", line 137, in export_tracking_number
2019-11-22 14:04:27,971 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     return tracking_exporter.run(record_id)
2019-11-22 14:04:27,982 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/magentoerpconnect/stock_tracking.py", line 104, in run
2019-11-22 14:04:27,997 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     self._validate(picking)
2019-11-22 14:04:28,010 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/magentoerpconnect/stock_tracking.py", line 48, in _validate
2019-11-22 14:04:28,023 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     if not picking.carrier_id.magento_carrier_code:
2019-11-22 14:04:28,032 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/fields.py", line 835, in __get__
2019-11-22 14:04:28,045 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     self.determine_value(record)
2019-11-22 14:04:28,059 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/fields.py", line 937, in determine_value
2019-11-22 14:04:28,067 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     self.compute_value(recs)
2019-11-22 14:04:28,081 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/fields.py", line 893, in compute_value
2019-11-22 14:04:28,097 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     self._compute_value(records)
2019-11-22 14:04:28,111 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/fields.py", line 885, in _compute_value
2019-11-22 14:04:28,123 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     self.compute(records)
2019-11-22 14:04:28,141 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/addons/magentoerpconnect/delivery.py", line 74, in _compute_carrier_code
2019-11-22 14:04:28,159 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     self.magento_carrier_code = carrier.magento_code.split('_')[0]
2019-11-22 14:04:28,171 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/fields.py", line 848, in __set__
2019-11-22 14:04:28,181 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     record.ensure_one()
2019-11-22 14:04:28,193 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `   File "/opt/runbot-addons/runbot/static/build/05349-wip-baf3fc/openerp/models.py", line 5347, in ensure_one
2019-11-22 14:04:28,211 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: `     raise except_orm("ValueError", "Expected singleton: %s" % self)
2019-11-22 14:04:28,229 12125 ERROR 05349-wip-baf3fc-all openerp.addons.magentoerpconnect.tests.test_export_picking: ` openerp.exceptions.except_orm: **('ValueError', 'Expected singleton: delivery.carrier(3, 11)')**