### PR TITLE
[12.0][ADD] Allow to import orders with a certain delay

### DIFF
--- a/connector_magento/doc/howto/configure_schedulers.rst
+++ b/connector_magento/doc/howto/configure_schedulers.rst
@@ -25,3 +25,22 @@ Activate the wanted schedulers:
 * Magento - Update Stock Quantities
 
 You can change the `Interval Number` and `Interval Unit` as well.
+
+------------------
+Order import delay
+------------------
+
+On the Magento backend itself you can configure an import delay. This delay is
+applied when fetching orders. Orders are fetched per timeframe, from the last
+import date up to the current timeframe, minus the delay (in minutes).
+
+The use case for this delay is the following combination of factors:
+
+* New orders are fetched frequently (every x minutes)
+* Orders are only imported when they are paid
+* Payment is processed externally and asynchronously so that orders are
+  confirmed in Magento sometime before they are marked as paid
+
+Depending on the delay at the payment provider, configuring a delay of one or
+two minutes might be enough to prevent the Magento connector from importing
+many orders twice (once unpaid and only then, paid).

--- a/connector_magento/models/magento_backend/common.py
+++ b/connector_magento/models/magento_backend/common.py
@@ -135,6 +135,9 @@ class MagentoBackend(models.Model):
     import_categories_from_date = fields.Datetime(
         string='Import categories from date',
     )
+    order_import_delay = fields.Integer(
+        help="Only import orders created earlier than ... minutes ago.",
+        default=0)
     product_stock_field_id = fields.Many2one(
         comodel_name='ir.model.fields',
         string='Stock Field',

--- a/connector_magento/models/magento_storeview/common.py
+++ b/connector_magento/models/magento_storeview/common.py
@@ -85,9 +85,8 @@ class MagentoStoreview(models.Model):
             delayable = sale_binding_model.with_delay(priority=1)
             filters = {
                 'magento_storeview_id': storeview.external_id,
-                'from_date': (fields.Datetime.to_string(from_date)
-                              if from_date else None),
-                'to_date': fields.Datetime.to_string(to_date),
+                'from_date': from_date or None,
+                'to_date': to_date,
             }
             delayable.import_batch(backend, filters=filters)
             # Records from Magento are imported based on their `created_at`

--- a/connector_magento/models/magento_storeview/common.py
+++ b/connector_magento/models/magento_storeview/common.py
@@ -74,32 +74,35 @@ class MagentoStoreview(models.Model):
                 sale_binding_model = sale_binding_model.sudo(user)
 
             backend = storeview.sudo(user).backend_id
-            if storeview.import_orders_from_date:
-                from_string = fields.Datetime.from_string
-                from_date = from_string(storeview.import_orders_from_date)
-            else:
-                from_date = None
+            from_date = storeview.import_orders_from_date
+
+            # Apply the global order import delay
+            to_date = import_start_time - timedelta(
+                minutes=backend.order_import_delay)
+            if from_date and to_date < from_date:
+                continue
 
             delayable = sale_binding_model.with_delay(priority=1)
             filters = {
                 'magento_storeview_id': storeview.external_id,
-                'from_date': from_date,
-                'to_date': import_start_time,
+                'from_date': (fields.Datetime.to_string(from_date)
+                              if from_date else None),
+                'to_date': fields.Datetime.to_string(to_date),
             }
             delayable.import_batch(backend, filters=filters)
-        # Records from Magento are imported based on their `created_at`
-        # date.  This date is set on Magento at the beginning of a
-        # transaction, so if the import is run between the beginning and
-        # the end of a transaction, the import of a record may be
-        # missed.  That's why we add a small buffer back in time where
-        # the eventually missed records will be retrieved.  This also
-        # means that we'll have jobs that import twice the same records,
-        # but this is not a big deal because the sales orders will be
-        # imported the first time and the jobs will be skipped on the
-        # subsequent imports
-        next_time = import_start_time - timedelta(seconds=IMPORT_DELTA_BUFFER)
-        next_time = fields.Datetime.to_string(next_time)
-        self.write({'import_orders_from_date': next_time})
+            # Records from Magento are imported based on their `created_at`
+            # date.  This date is set on Magento at the beginning of a
+            # transaction, so if the import is run between the beginning and
+            # the end of a transaction, the import of a record may be
+            # missed.  That's why we add a small buffer back in time where
+            # the eventually missed records will be retrieved.  This also
+            # means that we'll have jobs that import twice the same records,
+            # but this is not a big deal because the sales orders will be
+            # imported the first time and the jobs will be skipped on the
+            # subsequent imports
+            if not backend.order_import_delay:
+                to_date -= timedelta(seconds=IMPORT_DELTA_BUFFER)
+            storeview.write({'import_orders_from_date': to_date})
         return True
 
 

--- a/connector_magento/tests/__init__.py
+++ b/connector_magento/tests/__init__.py
@@ -1,3 +1,4 @@
+from . import test_batch_import
 from . import test_concurrent_sync
 from . import test_export_invoice
 from . import test_export_picking

--- a/connector_magento/tests/test_batch_import.py
+++ b/connector_magento/tests/test_batch_import.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Opener B.V.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from datetime import timedelta
+from odoo.fields import Datetime
+from .common import MagentoSyncTestCase
+
+
+class TestBatchImport(MagentoSyncTestCase):
+    def test_order_import_delay(self):
+        """ Batch import delay is honoured when importing orders """
+        storeview = self.env['magento.storeview'].search(
+            [('backend_id', '=', self.backend.id)], limit=1)
+        max_job_id = self.env['queue.job'].search(
+            [], order='id desc', limit=1).id or 0
+        self.backend.order_import_delay = 35
+        now = Datetime.now()
+        original_from_date = now - timedelta(hours=2)
+        storeview.import_orders_from_date = original_from_date
+        storeview.import_sale_orders()
+        job = self.env['queue.job'].search([('id', '>', max_job_id)])
+        self.assertTrue(job)
+        self.assertAlmostEqual(
+            Datetime.to_datetime(job.kwargs['filters']['from_date']),
+            original_from_date)
+        expected_to_date = now - timedelta(minutes=35)
+        to_date = Datetime.to_datetime(job.kwargs['filters']['to_date'])
+        self.assertAlmostEqual(to_date, expected_to_date, delta=timedelta(1))
+        self.assertAlmostEqual(
+            to_date, storeview.import_orders_from_date, delta=timedelta(1))

--- a/connector_magento/views/magento_backend_views.xml
+++ b/connector_magento/views/magento_backend_views.xml
@@ -145,6 +145,7 @@
                                 <field name="default_lang_id" widget="selection"/>
                                 <field name="default_category_id"/>
                                 <field name="sale_prefix" placeholder="mag-" />
+                                <field name="order_import_delay" />
                                 <field name="product_stock_field_id" widget="selection"
                                     domain="[('model', 'in', ['product.product', 'product.template']), ('ttype', '=', 'float')]"/>
                                 <field name="account_analytic_id" groups="analytic.group_analytic_accounting" />


### PR DESCRIPTION
This is useful when orders are imported frequently as it prevents orders
from being found unpaid if the transfer to status 'paid' is delayed at the
payment provider (set this value to the duration of that delay).