### PR TITLE
[12.0][FIX] Redundant error handling

### DIFF
--- a/connector_magento/components/backend_adapter.py
+++ b/connector_magento/components/backend_adapter.py
@@ -79,9 +79,6 @@ class Magento2Client(object):
         elif arguments is not None:
             kwargs['json'] = arguments
         res = function(url, **kwargs)
-        if (res.status_code == 400 and res._content):
-            raise requests.HTTPError(
-                url, res.status_code, res._content, headers, __name__)
         res.raise_for_status()
         return res.json()
 


### PR DESCRIPTION
raise_for_status() raises the same exception, with the response's _content
available from the exception's `response` attribute. Moreover, passing the
headers as a positional argument when creating the exception makes the
api key from the authorization header show up in the string representation
of the exception in logs and messages.