### PR TITLE
[IMP][12.0] Mute logging related to checkpoint notifications in tests

### DIFF
--- a/connector_magento/tests/magento2/common.py
+++ b/connector_magento/tests/magento2/common.py
@@ -13,6 +13,7 @@ Magento2 version of the helpers from tests/common.py
 from os.path import dirname, join
 from vcr import VCR
 
+from odoo.tools import mute_logger
 from ..common import MagentoTestCase
 
 
@@ -38,5 +39,9 @@ class Magento2TestCase(MagentoTestCase):
 class Magento2SyncTestCase(Magento2TestCase):
     def setUp(self):
         super(Magento2SyncTestCase, self).setUp()
-        with recorder.use_cassette('metadata'):
-            self.backend.synchronize_metadata()
+        with mute_logger(
+                'odoo.addons.mail.models.mail_mail',
+                'odoo.models.unlink',
+                'odoo.tests'):
+            with recorder.use_cassette('metadata'):
+                self.backend.synchronize_metadata()


### PR DESCRIPTION
```
2020-11-05 13:36:35,202 6822 INFO openerp_test odoo.tests: skip sending email in test mode
2020-11-05 13:36:35,206 6822 INFO openerp_test odoo.addons.mail.models.mail_mail: Mail with ID 1 and Message-Id '<342741149332557.1604583395.110157728195190-openerp-1-connector.checkpoint@travis-job-14c1db44-ca6c-40e2-82ff-03dcf3df66dc>' successfully sent
2020-11-05 13:36:35,227 6822 INFO openerp_test odoo.models.unlink: User #1 deleted mail.mail records with IDs: [1]
2020-11-05 13:36:35,228 6822 INFO openerp_test odoo.addons.mail.models.mail_mail: Sent batch 1 emails via mail server ID #False
```