### PR TITLE
[12.0][FIX] connector_magento: assign company from warehouse

### DIFF
--- a/connector_magento/models/sale_order/importer.py
+++ b/connector_magento/models/sale_order/importer.py
@@ -355,7 +355,10 @@ class SaleOrderImportMapper(Component):
     def warehouse_id(self, record):
         warehouse = self.options.storeview.warehouse_id
         if warehouse:
-            return {'warehouse_id': warehouse.id}
+            return {
+                'warehouse_id': warehouse.id,
+                'company_id': warehouse.company_id.id,
+            }
 
     # partner_id, partner_invoice_id, partner_shipping_id
     # are done in the importer


### PR DESCRIPTION
The fiscal position is fetched in the sale order's onchange methods from the
partner properties based on the company of the sale order. But the onchanges
are called on a newId that does not have a company_id assigned yet.

Assign the company from the warehouse to allow for multicompany setups.